### PR TITLE
[#97] Add travis for Cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cabal-dev
 cabal.sandbox.config
 cabal.config
 cabal.project.local
+.ghc.environment.*
 .HTF/
 # Stack
 .stack-work/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,40 +7,70 @@ git:
 cache:
   directories:
   - "$HOME/.stack"
-  - "$HOME/build/kowainik/summoner/.stack-work"
+  - "$TRAVIS_BUILD_DIR/.stack-work"
 
 matrix:
   include:
-
   - ghc: 8.2.2
-    env: GHCVER='8.2.2' STACK_YAML="$HOME/build/kowainik/summoner/stack-$GHCVER.yaml"
+    env: GHCVER='8.2.2' CABALVER='head'
+    os: linux
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.2.2
+        - cabal-install-head
 
   - ghc: 8.4.3
-    env: GHCVER='8.4.3' STACK_YAML="$HOME/build/kowainik/summoner/stack.yaml"
+    env: GHCVER='8.4.3' CABALVER='head'
+    os: linux
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.4.3
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'ppa:hvr/ghc'
-    packages:
-      - libgmp-dev
+  - ghc: 8.2.2
+    env: GHCVER='8.2.2' STACK_YAML="$TRAVIS_BUILD_DIR/stack-$GHCVER.yaml"
+    os: linux
+    addons:
+      apt:
+        packages:
+        - libgmp-dev
 
-before_install:
-  - mkdir -p ~/.local/bin
-  - export PATH="$HOME/.local/bin:$PATH"
-  - travis_retry curl -L 'https://www.stackage.org/stack/linux-x86_64' | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-  - stack --version
-
+  - ghc: 8.4.3
+    env: GHCVER='8.4.3' STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
+    os: linux
+    addons:
+      apt:
+        packages:
+        - libgmp-dev
 
 install:
-  - travis_wait 30 stack setup --no-terminal
-  - stack ghc -- --version
-
-  - travis_wait 40 stack build --only-dependencies --no-terminal
-  - travis_wait 40 stack build --test --bench --haddock --no-run-tests --no-run-benchmarks --no-haddock-deps --no-terminal
-
+  - |
+    if [ -z "$STACK_YAML" ]; then
+      export PATH="/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH"
+      echo $PATH
+      cabal new-update
+      cabal new-build --enable-tests --enable-benchmarks
+    else
+      mkdir -p ~/.local/bin
+      export PATH="$HOME/.local/bin:$PATH"
+      travis_retry curl -L 'https://www.stackage.org/stack/linux-x86_64' | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+      stack --version
+      stack setup --no-terminal --install-cabal 2.0.1.0
+      stack ghc -- --version
+      stack build --only-dependencies --no-terminal
+    fi
 script:
-  - travis_wait 40 stack build --test --no-terminal
+  - |
+    if [ -z "$STACK_YAML" ]; then
+       cabal new-test
+    else
+      stack build --test --no-terminal
+    fi
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   Bump up to `ghc-8.4.3`. Add support for `Ghc843` in code
   and make it default.
 * Make CI badges in README be shown depending on the chosen options.
+* [#99](https://github.com/kowainik/summoner/issues/99):
+  UseTravis-specific env variable `TRAVIS_BUILD_DIR` in created travis file.
+* [#97](https://github.com/kowainik/summoner/issues/97):
+  Add cabal to created travis file.
 
 1.0.4
 =====


### PR DESCRIPTION
Resolves #97 
Resolves #99 

Tested on [this](https://github.com/vrom911/new) project. See generated Travis file: https://github.com/vrom911/new/blob/master/.travis.yml . Note, that `cabal new-test` fails if there are no tests, so I made another check and making simple `echo` if test stanza was not chosen.