### PR TITLE
[#125] Move Decision and GhcVer into their own modules

### DIFF
--- a/src/Summoner/CLI.hs
+++ b/src/Summoner/CLI.hs
@@ -22,9 +22,10 @@ import Paths_summoner (version)
 import Summoner.Ansi (Color (Green), beautyPrint, bold, errorMessage, infoMessage, setColor,
                       warningMessage)
 import Summoner.Config (ConfigP (..), PartialConfig, defaultConfig, finalise, loadFileConfig)
+import Summoner.Decision (Decision (..))
 import Summoner.Default (defaultConfigFile, endLine)
 import Summoner.Project (generateProject)
-import Summoner.ProjectData (CustomPrelude (..), Decision (..))
+import Summoner.ProjectData (CustomPrelude (..))
 import Summoner.Validation (Validation (..))
 
 ---------------------------------------------------------------------------

--- a/src/Summoner/Config.hs
+++ b/src/Summoner/Config.hs
@@ -33,9 +33,10 @@ import Generics.Deriving.Monoid (GMonoid, gmemptydefault)
 import Generics.Deriving.Semigroup (GSemigroup, gsappenddefault)
 import Toml (AnyValue (..), BiToml, Key, Prism (..), dimap, (.=))
 
+import Summoner.Decision (Decision (..))
+import Summoner.GhcVer (GhcVer (..), parseGhcVer, showGhcVer)
 import Summoner.License (LicenseName (..), parseLicenseName)
-import Summoner.ProjectData (CustomPrelude (..), Decision (..), GhcVer (..), parseGhcVer,
-                             showGhcVer)
+import Summoner.ProjectData (CustomPrelude (..))
 import Summoner.Validation (Validation (..))
 
 import qualified Text.Show as Show

--- a/src/Summoner/Decision.hs
+++ b/src/Summoner/Decision.hs
@@ -1,3 +1,5 @@
+-- | Decision data type.
+
 module Summoner.Decision
        ( Decision (..)
        , decisionToBool
@@ -10,9 +12,6 @@ import Generics.Deriving.Semigroup (GSemigroup (..))
 
 import Summoner.Question (chooseYesNoBool, falseMessage, trueMessage)
 
-----------------------------------------------------------------------------
--- Decision data type
-----------------------------------------------------------------------------
 
 -- | Used for detecting the user decision during CLI input.
 data Decision = Idk | Nop | Yes

--- a/src/Summoner/Decision.hs
+++ b/src/Summoner/Decision.hs
@@ -1,0 +1,42 @@
+module Summoner.Decision
+       ( Decision (..)
+       , decisionToBool
+       ) where
+
+import Relude
+
+import Generics.Deriving.Monoid (GMonoid (..))
+import Generics.Deriving.Semigroup (GSemigroup (..))
+
+import Summoner.Question (chooseYesNoBool, falseMessage, trueMessage)
+
+----------------------------------------------------------------------------
+-- Decision data type
+----------------------------------------------------------------------------
+
+-- | Used for detecting the user decision during CLI input.
+data Decision = Idk | Nop | Yes
+    deriving (Show, Eq, Enum, Bounded, Generic)
+
+instance Semigroup Decision where
+    (<>) :: Decision -> Decision -> Decision
+    Idk <> x   = x
+    x   <> Idk = x
+    _   <> x   = x
+
+instance Monoid Decision where
+    mempty  = Idk
+    mappend = (<>)
+
+instance GSemigroup Decision where
+    gsappend = (<>)
+
+instance GMonoid Decision where
+    gmempty = mempty
+    gmappend = (<>)
+
+decisionToBool :: Decision -> Text -> IO Bool
+decisionToBool decision target = case decision of
+    Yes -> trueMessage  target
+    Nop -> falseMessage target
+    Idk -> chooseYesNoBool target

--- a/src/Summoner/Default.hs
+++ b/src/Summoner/Default.hs
@@ -14,14 +14,15 @@ import Data.Time (getCurrentTime, toGregorian, utctDay)
 import System.Directory (getHomeDirectory)
 import System.FilePath ((</>))
 
-import Summoner.GhcVer (GhcVer (Ghc843))
+import Summoner.GhcVer (GhcVer)
 
 ----------------------------------------------------------------------------
 -- Default Settings
 ----------------------------------------------------------------------------
 
+-- | Default GHC version is the latest available.
 defaultGHC :: GhcVer
-defaultGHC = Ghc843
+defaultGHC = maxBound
 
 defaultTomlFile :: String
 defaultTomlFile = ".summoner.toml"

--- a/src/Summoner/Default.hs
+++ b/src/Summoner/Default.hs
@@ -14,7 +14,7 @@ import Data.Time (getCurrentTime, toGregorian, utctDay)
 import System.Directory (getHomeDirectory)
 import System.FilePath ((</>))
 
-import Summoner.ProjectData (GhcVer (Ghc843))
+import Summoner.GhcVer (GhcVer (Ghc843))
 
 ----------------------------------------------------------------------------
 -- Default Settings

--- a/src/Summoner/GhcVer.hs
+++ b/src/Summoner/GhcVer.hs
@@ -1,0 +1,49 @@
+module Summoner.GhcVer
+       ( GhcVer (..)
+       , showGhcVer
+       , parseGhcVer
+       , latestLts
+       , baseVer
+       ) where
+
+import Relude
+import Relude.Extra.Enum (inverseMap)
+
+-- | Represents some selected set of GHC versions.
+data GhcVer
+    = Ghc7103
+    | Ghc801
+    | Ghc802
+    | Ghc822
+    | Ghc843
+    deriving (Eq, Ord, Show, Enum, Bounded)
+
+-- | Converts 'GhcVer' into dot-separated string.
+showGhcVer :: GhcVer -> Text
+showGhcVer = \case
+    Ghc7103 -> "7.10.3"
+    Ghc801  -> "8.0.1"
+    Ghc802  -> "8.0.2"
+    Ghc822  -> "8.2.2"
+    Ghc843  -> "8.4.3"
+
+parseGhcVer :: Text -> Maybe GhcVer
+parseGhcVer = inverseMap showGhcVer
+
+-- | Returns latest known LTS resolver for all GHC versions except default one.
+latestLts :: GhcVer -> Text
+latestLts = \case
+    Ghc7103 -> "6.35"
+    Ghc801  -> "7.24"
+    Ghc802  -> "9.21"
+    Ghc822  -> "11.22"
+    Ghc843  -> "12.7"
+
+-- | Returns base version by 'GhcVer'.
+baseVer :: GhcVer -> Text
+baseVer = \case
+    Ghc7103 -> "4.8.0.2"
+    Ghc801  -> "4.9.0.0"
+    Ghc802  -> "4.9.1.0"
+    Ghc822  -> "4.10.1.0"
+    Ghc843  -> "4.11.1.0"

--- a/src/Summoner/Project.hs
+++ b/src/Summoner/Project.hs
@@ -18,23 +18,17 @@ import System.Process (readProcess)
 
 import Summoner.Ansi (errorMessage, infoMessage, successMessage)
 import Summoner.Config (Config, ConfigP (..))
+import Summoner.Decision (Decision (..), decisionToBool)
 import Summoner.Default (currentYear, defaultGHC)
+import Summoner.GhcVer (parseGhcVer, showGhcVer)
 import Summoner.License (License (..), customizeLicense, githubLicenseQueryNames, parseLicenseName)
 import Summoner.Process ()
-import Summoner.ProjectData (CustomPrelude (..), Decision (..), ProjectData (..), parseGhcVer,
-                             showGhcVer)
-import Summoner.Question (checkUniqueName, choose, chooseYesNo, chooseYesNoBool, falseMessage,
-                          query, queryDef, queryManyRepeatOnFail, targetMessageWithText,
-                          trueMessage)
-import Summoner.Template (createStackTemplate)
+import Summoner.ProjectData (CustomPrelude (..), ProjectData (..))
+import Summoner.Question (checkUniqueName, choose, chooseYesNo, falseMessage, query, queryDef,
+                          queryManyRepeatOnFail, targetMessageWithText, trueMessage)
+import Summoner.Template (createProjectTemplate)
 import Summoner.Text (intercalateMap, packageToModule)
 import Summoner.Tree (showTree, traverseTree)
-
-decisionToBool :: Decision -> Text -> IO Bool
-decisionToBool decision target = case decision of
-    Yes -> trueMessage  target
-    Nop -> falseMessage target
-    Idk -> chooseYesNoBool target
 
 -- | Generate the project.
 generateProject :: Text -> Config -> IO ()
@@ -115,7 +109,7 @@ generateProject projectName Config{..} = do
 
     createProjectDirectory :: ProjectData -> IO ()
     createProjectDirectory projectData@ProjectData{..} = do
-        let tree = createStackTemplate projectData
+        let tree = createProjectTemplate projectData
         traverseTree tree
         successMessage "\nThe project with the following structure has been created:"
         putTextLn $ showTree tree

--- a/src/Summoner/ProjectData.hs
+++ b/src/Summoner/ProjectData.hs
@@ -2,28 +2,19 @@
 
 module Summoner.ProjectData
        ( ProjectData (..)
-       , GhcVer (..)
-       , parseGhcVer
-       , showGhcVer
-       , latestLts
-       , baseNopreludeVer
-
-       , Decision (..)
        , CustomPrelude (..)
-
-       , Answer (..)
-       , yesOrNo
        ) where
 
 import Relude
-import Relude.Extra.Enum (inverseMap)
 
-import Generics.Deriving.Monoid (GMonoid (..))
-import Generics.Deriving.Semigroup (GSemigroup (..))
-
+import Summoner.GhcVer (GhcVer)
 import Summoner.License (LicenseName)
 
-import qualified Data.Text as T
+
+data CustomPrelude = Prelude
+    { cpPackage :: Text
+    , cpModule  :: Text
+    } deriving (Show, Eq)
 
 -- | Data needed for project creation.
 data ProjectData = ProjectData
@@ -52,72 +43,3 @@ data ProjectData = ProjectData
     , cabal          :: Bool
     , stack          :: Bool
     } deriving (Show)
-
--- | Used for detecting the user decision during CLI input.
-data Decision = Yes | Nop | Idk
-    deriving (Show, Eq, Enum, Bounded, Generic)
-
-instance Semigroup Decision where
-    (<>) :: Decision -> Decision -> Decision
-    Idk <> x   = x
-    x   <> Idk = x
-    _   <> x   = x
-
-instance Monoid Decision where
-    mempty  = Idk
-    mappend = (<>)
-
-instance GSemigroup Decision where
-    gsappend = (<>)
-
-instance GMonoid Decision where
-    gmempty = mempty
-    gmappend = (<>)
-
--- | Represents some selected set of GHC versions.
-data GhcVer = Ghc7103
-            | Ghc801
-            | Ghc802
-            | Ghc822
-            | Ghc843
-            deriving (Eq, Ord, Show, Enum, Bounded)
-
--- | Converts 'GhcVer' into dot-separated string.
-showGhcVer :: GhcVer -> Text
-showGhcVer Ghc7103 = "7.10.3"
-showGhcVer Ghc801  = "8.0.1"
-showGhcVer Ghc802  = "8.0.2"
-showGhcVer Ghc822  = "8.2.2"
-showGhcVer Ghc843  = "8.4.3"
-
-parseGhcVer :: Text -> Maybe GhcVer
-parseGhcVer = inverseMap showGhcVer
-
--- | Returns latest known LTS resolver for all GHC versions except default one.
-latestLts :: GhcVer -> Text
-latestLts Ghc7103 = "6.35"
-latestLts Ghc801  = "7.24"
-latestLts Ghc802  = "9.21"
-latestLts Ghc822  = "11.17"
-latestLts Ghc843  = "12.2"
-
-baseNopreludeVer :: GhcVer -> Text
-baseNopreludeVer Ghc7103 = "4.8.0.2"
-baseNopreludeVer Ghc801  = "4.9.0.0"
-baseNopreludeVer Ghc802  = "4.9.1.0"
-baseNopreludeVer Ghc822  = "4.10.1.0"
-baseNopreludeVer Ghc843  = "4.11.1.0"
-
-data CustomPrelude = Prelude
-    { cpPackage :: Text
-    , cpModule  :: Text
-    } deriving (Show, Eq)
-
-data Answer = Y | N
-
-yesOrNo :: Text -> Maybe Answer
-yesOrNo (T.toLower -> answer )
-    | T.null answer = Just Y
-    | answer `elem` ["yes", "y", "ys"] = Just Y
-    | answer `elem` ["no", "n"]  = Just N
-    | otherwise = Nothing

--- a/src/Summoner/Question.hs
+++ b/src/Summoner/Question.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 -- | This module contains function to proper questioning in terminal.
 
@@ -28,12 +29,24 @@ import System.FilePath ((</>))
 
 import Summoner.Ansi (Color (..), beautyPrint, bold, boldDefault, errorMessage, italic, prompt,
                       putStrFlush, setColor, warningMessage)
-import Summoner.ProjectData (Answer (..), yesOrNo)
 import Summoner.Text (headToUpper, intercalateMap)
 
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Relude.Unsafe as Unsafe
+
+----------------------------------------------------------------------------
+-- Yes/No
+----------------------------------------------------------------------------
+
+data Answer = Y | N
+
+yesOrNo :: Text -> Maybe Answer
+yesOrNo (T.toLower -> answer )
+    | T.null answer = Just Y
+    | answer `elem` ["yes", "y", "ys"] = Just Y
+    | answer `elem` ["no", "n"]  = Just N
+    | otherwise = Nothing
 
 ----------------------------------------------------------------------------
 -- IO Questioning

--- a/src/Summoner/Template.hs
+++ b/src/Summoner/Template.hs
@@ -5,7 +5,7 @@
 -- | This module contains functions for stack template creation.
 
 module Summoner.Template
-       ( createStackTemplate
+       ( createProjectTemplate
        ) where
 
 import Relude
@@ -14,23 +14,23 @@ import Data.List (delete)
 import NeatInterpolation (text)
 
 import Summoner.Default (defaultGHC, endLine)
-import Summoner.ProjectData (CustomPrelude (..), GhcVer (..), ProjectData (..), baseNopreludeVer,
-                             latestLts, showGhcVer)
+import Summoner.GhcVer (GhcVer (..), baseVer, latestLts, showGhcVer)
+import Summoner.ProjectData (CustomPrelude (..), ProjectData (..))
 import Summoner.Text (intercalateMap, packageToModule)
 import Summoner.Tree (TreeFs (..))
 
 import qualified Data.Text as T
 
 ----------------------------------------------------------------------------
--- Stack File Creation
+-- Project Directory Creation
 ----------------------------------------------------------------------------
 
 memptyIfFalse :: Monoid m => Bool -> m -> m
 memptyIfFalse p val = if p then val else mempty
 
 -- | Creating template file to use in `stack new` command
-createStackTemplate :: ProjectData ->  TreeFs
-createStackTemplate ProjectData{..} = Dir (toString repo) $
+createProjectTemplate :: ProjectData ->  TreeFs
+createProjectTemplate ProjectData{..} = Dir (toString repo) $
     [ File (toString repo <> ".cabal")
            ( createCabalTop
           <> memptyIfFalse github createCabalGit
@@ -588,10 +588,10 @@ createStackTemplate ProjectData{..} = Dir (toString repo) $
         createStackYaml ghcV = let ver = case ghcV of
                                       Ghc843 -> ""
                                       _      -> "-" <> showGhcVer ghcV
-            in stackYaml ver (latestLts ghcV) (baseNopreludeVer ghcV)
+            in stackYaml ver (latestLts ghcV) (baseVer ghcV)
           where
             stackYaml :: Text -> Text -> Text -> TreeFs
-            stackYaml ghc lts baseVer = File (toString $ "stack" <> ghc <> ".yaml")
+            stackYaml ghc lts baseV = File (toString $ "stack" <> ghc <> ".yaml")
                 [text|
                 resolver: lts-${lts}
 
@@ -604,7 +604,7 @@ createStackTemplate ProjectData{..} = Dir (toString repo) $
                 extraDeps :: Text
                 extraDeps = case prelude of
                     Nothing -> ""
-                    Just _  -> "extra-deps: [base-noprelude-" <> baseVer <> "]"
+                    Just _  -> "extra-deps: [base-noprelude-" <> baseV <> "]"
                 ghcOpts :: Text
                 ghcOpts = if ghcV <= Ghc802 then
                             ""

--- a/src/Summoner/Template.hs
+++ b/src/Summoner/Template.hs
@@ -28,7 +28,7 @@ import qualified Data.Text as T
 memptyIfFalse :: Monoid m => Bool -> m -> m
 memptyIfFalse p val = if p then val else mempty
 
--- | Creating template file to use in `stack new` command
+-- | Creating tree structure of the project.
 createProjectTemplate :: ProjectData ->  TreeFs
 createProjectTemplate ProjectData{..} = Dir (toString repo) $
     [ File (toString repo <> ".cabal")

--- a/summoner.cabal
+++ b/summoner.cabal
@@ -29,7 +29,9 @@ library
                          Summoner.Ansi
                          Summoner.CLI
                          Summoner.Config
+                         Summoner.Decision
                          Summoner.Default
+                         Summoner.GhcVer
                          Summoner.License
                          Summoner.Process
                          Summoner.Project
@@ -78,9 +80,9 @@ library
 executable summon
   hs-source-dirs:      app
   main-is:             Main.hs
-  ghc-options:         -Wall 
-                       -threaded  
-                       -rtsopts 
+  ghc-options:         -Wall
+                       -threaded
+                       -rtsopts
                        -with-rtsopts=-N
                        -Wincomplete-uni-patterns
                        -Wincomplete-record-updates
@@ -111,9 +113,9 @@ test-suite summoner-test
                      , summoner
   default-extensions:  NoImplicitPrelude
 
-  ghc-options:         -Wall 
-                       -threaded 
-                       -rtsopts 
+  ghc-options:         -Wall
+                       -threaded
+                       -rtsopts
                        -with-rtsopts=-N
                        -Wincomplete-uni-patterns
                        -Wincomplete-record-updates

--- a/test/Test/DecisionSpec.hs
+++ b/test/Test/DecisionSpec.hs
@@ -6,7 +6,7 @@ import Hedgehog (MonadGen, forAll, property, (===))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testProperty)
 
-import Summoner.ProjectData (Decision)
+import Summoner.Decision (Decision)
 
 import qualified Hedgehog.Gen as Gen
 

--- a/test/Test/TomlSpec.hs
+++ b/test/Test/TomlSpec.hs
@@ -11,8 +11,9 @@ import Test.Tasty.Hedgehog (testProperty)
 import Toml.Bi.Code (decode, encode)
 
 import Summoner.Config (ConfigP (..), PartialConfig, configT)
+import Summoner.GhcVer (GhcVer)
 import Summoner.License (LicenseName)
-import Summoner.ProjectData (CustomPrelude (..), GhcVer (..))
+import Summoner.ProjectData (CustomPrelude (..))
 import Test.DecisionSpec (genDecision)
 
 import qualified Hedgehog.Gen as Gen


### PR DESCRIPTION
This is only a step in breaking `Template` into smaller pieces. Breaking `Template` requires to introduce about 20 `newtype`s in `ProjectData` module. So I decided to move `GhcVer` and `Decision` into separate modules to not mix different things.

This PR also contains some other refactoring.