### PR TITLE
[#156] Add build-depends constraint

### DIFF
--- a/summoner.cabal
+++ b/summoner.cabal
@@ -48,18 +48,18 @@ library
   autogen-modules:     Paths_summoner
 
   build-depends:       base-noprelude >= 4.10 && < 5
-                     , aeson
-                     , ansi-terminal
-                     , bytestring
-                     , directory
-                     , filepath
-                     , generic-deriving
-                     , gitrev
+                     , aeson >= 1.2.4.0 && < 1.5
+                     , ansi-terminal ^>= 0.8.0.4
+                     , bytestring ^>= 0.10.8.2
+                     , directory ^>= 1.3.0.2
+                     , filepath ^>= 1.4.1.2
+                     , generic-deriving ^>= 1.12.2
+                     , gitrev ^>= 1.3.1
                      , neat-interpolation ^>= 0.3.2.2
-                     , optparse-applicative
-                     , process
-                     , text
-                     , time
+                     , optparse-applicative ^>= 0.14.2.0
+                     , process ^>= 1.6.1.0
+                     , text ^>= 1.2.3.0
+                     , time ^>= 1.8
                      , tomland ^>= 0.4.0
                      , relude ^>= 0.3.0
 


### PR DESCRIPTION
Resolves #156 

This is a temporary fix. Should be reverted after migration to newer `tomland` version (see #155). Also, we should add more bounds later.