### PR TITLE
[#154] - Add Link constructor to Source data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Summoner
 
+1.2.0
+=======
+
+* [#154](https://github.com/kowainik/summoner/issues/154):
+* Add `Link` constructor to `Source` data type.
+
 1.1.0.1
 =======
 

--- a/src/Summoner/Source.hs
+++ b/src/Summoner/Source.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Summoner.Source
        ( Source (..)
@@ -6,13 +6,13 @@ module Summoner.Source
        , fetchSource
        ) where
 
-import           Control.Arrow ((>>>))
-import           Control.Exception (catch)
-import           NeatInterpolation (text)
-import           System.Process (readProcess)
-import           Toml (BiMap, BiToml, Key)
+import Control.Arrow ((>>>))
+import Control.Exception (catch)
+import NeatInterpolation (text)
+import System.Process (readProcess)
+import Toml (BiMap, BiToml, Key)
 
-import           Summoner.Ansi (errorMessage)
+import Summoner.Ansi (errorMessage)
 
 import qualified Toml
 
@@ -48,7 +48,7 @@ fetchSource :: Source -> IO (Maybe Text)
 fetchSource = \case
     File path -> catch (Just <$> readFileText path) (fileError path)
     Url url -> catch (fetchUrl url) (urlError url)
-    Link link -> catch (putLink link) (urlError link)
+    Link link -> putLink link
   where
     fileError :: FilePath -> SomeException -> IO (Maybe Text)
     fileError path _ = errorMessage ("Couldn't read file: " <> toText path)

--- a/summoner.cabal
+++ b/summoner.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                summoner
-version:             1.1.0.1
+version:             1.2.0
 synopsis:            Tool for creating completely configured production Haskell projects.
 description:         Tool for creating completely configured production Haskell projects.
                      See README.md for details.

--- a/test/Test/TomlSpec.hs
+++ b/test/Test/TomlSpec.hs
@@ -38,12 +38,6 @@ genSource = do
     s   <- Gen.element [File . toString, Url]
     pure $ s txt
 
-genSourceContrib :: MonadGen m => m Source
-genSourceContrib = do
-    txt <- genText
-    s   <- Gen.element [File . toString, Url, Link]
-    pure $ s txt
-
 genPartialConfig :: MonadGen m => m PartialConfig
 genPartialConfig = do
     cOwner      <- Last . Just <$> genText
@@ -65,7 +59,7 @@ genPartialConfig = do
     cExtensions <- genTextArr
     cWarnings   <- genTextArr
     cStylish    <- Last <$> Gen.maybe genSource
-    cContributing <- Last <$> Gen.maybe genSourceContrib
+    cContributing <- Last <$> Gen.maybe genSource
     pure Config{..}
 
 test_Toml :: [TestTree]

--- a/test/Test/TomlSpec.hs
+++ b/test/Test/TomlSpec.hs
@@ -35,7 +35,7 @@ genLicense = Gen.element universe
 genSource :: MonadGen m => m Source
 genSource = do
     txt <- genText
-    s   <- Gen.element [File . toString, Url]
+    s   <- Gen.element [File . toString, Url, Link]
     pure $ s txt
 
 genPartialConfig :: MonadGen m => m PartialConfig

--- a/test/Test/TomlSpec.hs
+++ b/test/Test/TomlSpec.hs
@@ -38,6 +38,12 @@ genSource = do
     s   <- Gen.element [File . toString, Url]
     pure $ s txt
 
+genSourceContrib :: MonadGen m => m Source
+genSourceContrib = do
+    txt <- genText
+    s   <- Gen.element [File . toString, Url, Link]
+    pure $ s txt
+
 genPartialConfig :: MonadGen m => m PartialConfig
 genPartialConfig = do
     cOwner      <- Last . Just <$> genText
@@ -59,7 +65,7 @@ genPartialConfig = do
     cExtensions <- genTextArr
     cWarnings   <- genTextArr
     cStylish    <- Last <$> Gen.maybe genSource
-    cContributing <- Last <$> Gen.maybe genSource
+    cContributing <- Last <$> Gen.maybe genSourceContrib
     pure Config{..}
 
 test_Toml :: [TestTree]


### PR DESCRIPTION
this fixes #154 
but I have failing tests and I'm not sure I'm carrying it out the right way.
`cContributing` is having a bit of a nightmare but I wonder why would `Link` differ from `Url`?