### PR TITLE
modfiy tree pretty-printer arm symbol

### DIFF
--- a/src/Summoner/Tree.hs
+++ b/src/Summoner/Tree.hs
@@ -47,7 +47,7 @@ showOne leader tie arm (Dir fp (sortWith treeFp -> trees)) =
 
 showChildren :: [TreeFs] -> Text -> [Text]
 showChildren children leader =
-    let arms = replicate (length children - 1) "│" <> ["└"]
+    let arms = replicate (length children - 1) "├" <> ["└"]
     in  concat (zipWith (showOne leader "── ") arms children)
 
 -- For sorting in alphabetic order.


### PR DESCRIPTION
This fixes [#126]:  
replaced | with ├  to make the tree look like the "tree" cli tool.
Simplest fix ever :D