### PR TITLE
WIP: Add simple Nix support

### DIFF
--- a/src/Summoner/CLI.hs
+++ b/src/Summoner/CLI.hs
@@ -186,6 +186,7 @@ newP = do
     ignoreFile  <- ignoreFileP
     cabal   <- cabalP
     stack   <- stackP
+    nix     <- nixP
     with    <- optional withP
     without <- optional withoutP
     file    <- optional fileP
@@ -197,6 +198,7 @@ newP = do
             { cPrelude = Last $ Prelude <$> preludePack <*> preludeMod
             , cCabal = cabal
             , cStack = stack
+            , cNix = nix
             }
 
 targetsP ::  Decision -> Parser PartialConfig
@@ -311,6 +313,11 @@ stackP :: Parser Decision
 stackP = flag Idk Yes
        $ long "stack"
       <> help "Stack support for the project"
+
+nixP :: Parser Decision
+nixP = flag Idk Yes
+     $ long "nix"
+     <> help "Nix support for the project"
 
 ----------------------------------------------------------------------------
 -- Beauty util

--- a/src/Summoner/Config.hs
+++ b/src/Summoner/Config.hs
@@ -48,6 +48,7 @@ data ConfigP (p :: Phase) = Config
     , cGhcVer       :: p :- [GhcVer]
     , cCabal        :: Decision
     , cStack        :: Decision
+    , cNix          :: Decision
     , cGitHub       :: Decision
     , cTravis       :: Decision
     , cAppVey       :: Decision
@@ -112,6 +113,7 @@ defaultConfig = Config
     , cGhcVer   = Last (Just [])
     , cCabal    = Idk
     , cStack    = Idk
+    , cNix      = Idk
     , cGitHub   = Idk
     , cTravis   = Idk
     , cAppVey   = Idk
@@ -137,6 +139,7 @@ configT = Config
     <*> lastT ghcVerArr "ghcVersions" .= cGhcVer
     <*> decision        "cabal"       .= cCabal
     <*> decision        "stack"       .= cStack
+    <*> decision        "nix"         .= cNix
     <*> decision        "github"      .= cGitHub
     <*> decision        "travis"      .= cTravis
     <*> decision        "appveyor"    .= cAppVey
@@ -211,6 +214,7 @@ finalise Config{..} = Config
     <*> fin  "ghcVersions" cGhcVer
     <*> pure cCabal
     <*> pure cStack
+    <*> pure cNix
     <*> pure cGitHub
     <*> pure cTravis
     <*> pure cAppVey

--- a/src/Summoner/License.hs
+++ b/src/Summoner/License.hs
@@ -3,6 +3,7 @@ module Summoner.License
        , License(..)
        , customizeLicense
        , githubLicenseQueryNames
+       , nixLicenseNames
        , parseLicenseName
        , fetchLicense
        ) where
@@ -61,6 +62,19 @@ githubLicenseQueryNames = \case
     AGPL3    -> "agpl-3.0"
     Apache20 -> "apache-2.0"
     MPL20    -> "mpl-2.0"
+
+nixLicenseNames :: LicenseName -> Text
+nixLicenseNames = \case
+    MIT      -> "mit"
+    BSD2     -> "bsd2"
+    BSD3     -> "bsd3"
+    GPL2     -> "gpl2"
+    GPL3     -> "gpl3"
+    LGPL21   -> "lgpl21"
+    LGPL3    -> "lgpl3"
+    AGPL3    -> "agpl3"
+    Apache20 -> "asl20"
+    MPL20    -> "mpl20"
 
 parseLicenseName :: Text -> Maybe LicenseName
 parseLicenseName = inverseMap show

--- a/src/Summoner/Project.hs
+++ b/src/Summoner/Project.hs
@@ -30,6 +30,7 @@ generateProject projectName Config{..} = do
     repo        <- checkUniqueName projectName
     -- decide cabal stack or both
     (cabal, stack) <- getCabalStack (cCabal, cStack)
+    nix <- decisionToBool cNix "Nix support"
 
     owner       <- queryDef "Repository owner: " cOwner
     description <- query "Short project description: "

--- a/src/Summoner/ProjectData.hs
+++ b/src/Summoner/ProjectData.hs
@@ -37,6 +37,7 @@ data ProjectData = ProjectData
     , warnings       :: [Text] -- ^ default warnings
     , cabal          :: Bool
     , stack          :: Bool
+    , nix            :: Bool
     , stylish        :: Maybe Text -- ^ @.stylish-haskell.yaml@ file
     , contributing   :: Maybe Text -- ^ @CONTRIBUTING.md@ file
     } deriving (Show)

--- a/test/Test/TomlSpec.hs
+++ b/test/Test/TomlSpec.hs
@@ -47,6 +47,7 @@ genPartialConfig = do
     cGhcVer     <- Last . Just <$> genGhcVerArr
     cCabal      <- genDecision
     cStack      <- genDecision
+    cNix        <- genDecision
     cGitHub     <- genDecision
     cTravis     <- genDecision
     cAppVey     <- genDecision


### PR DESCRIPTION
Trying a simple approach to adding bare minimum Nix support to a created project without invoking something external like `cabal2nix`, which could be feasible. Instead I'm thinking if we reuse the information already present in the cabal file generator, then we have enough for a working Nix derivation:

```shell
$ summon new foo
  Default config /home/kenny/.summoner.toml file is missing.
Add cabal? [y]/n
  ->   
  Cabal will be added to the project
Add stack? [y]/n
  ->   
  Stack will be added to the project
Add Nix support? [y]/n
  ->   
  Nix support will be added to the project
Repository owner:  [kowainik]
...

$ cd foo

$ nix-build
these derivations will be built:
  /nix/store/iig7f13cxc85pprcqikah1vh3x8q31qz-foo-0.0.0.drv
building '/nix/store/iig7f13cxc85pprcqikah1vh3x8q31qz-foo-0.0.0.drv'...
setupCompilerEnvironmentPhase
Build with /nix/store/sx4pjh0nh0acqszld5rrxwbjnzl3djrg-ghc-8.4.3.
ignoring (possibly broken) abi-depends field for packages
unpacking sources
...

$ ./result/bin/foo
someFunc

```

Thoughts?