### PR TITLE
fix: change appveyor config file to 64 bit (stack & generated binary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 1.2.0
 =======
 
+* [#169](https://github.com/kowainik/summoner/issues/169):
+  Make AppVeyor use the 64bits version of stack and build for 64 bits.
 * [#154](https://github.com/kowainik/summoner/issues/154):
 * Add `Link` constructor to `Source` data type.
 

--- a/src/Summoner/Template.hs
+++ b/src/Summoner/Template.hs
@@ -628,7 +628,7 @@ createProjectTemplate ProjectData{..} = Dir (toString repo) $
         # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
         - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
-        - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+        - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
         - 7z x stack.zip stack.exe
 
         clone_folder: "c:\\stack"
@@ -640,5 +640,5 @@ createProjectTemplate ProjectData{..} = Dir (toString repo) $
         - stack setup > nul
         # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
         # descriptor
-        - echo "" | stack --no-terminal build --bench --no-run-benchmarks --test
+        - echo "" | stack --arch x86_64 --no-terminal build --bench --no-run-benchmarks --test
         |]


### PR DESCRIPTION
- change is limited to the template for appveyor config file
- tested with a project generated with the new version of summon which builds ok in appveyor
- **tested only with GHC 8.4.3**

closes https://github.com/kowainik/summoner/issues/169