### PR TITLE
`settingsTestedVersions` is of type `NonEmpty GhcVer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 1.2.0
 =======
 
+* [#179](https://github.com/kowainik/summoner/issues/179):
+  Make list of GHC versions `NonEmpty`.
 * [#169](https://github.com/kowainik/summoner/issues/169):
   Make AppVeyor use the 64bits version of stack and build for 64 bits.
 * [#154](https://github.com/kowainik/summoner/issues/154):

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -6,6 +6,7 @@ module Prelude
 
        , endLine
        , memptyIfFalse
+       , toListMap
        ) where
 
 import Relude
@@ -16,3 +17,6 @@ endLine = "\n"
 
 memptyIfFalse :: Monoid m => Bool -> m -> m
 memptyIfFalse p val = if p then val else mempty
+
+toListMap :: Foldable f => (a -> b) -> f a -> [b]
+toListMap f = map f . toList

--- a/src/Summoner/Project.hs
+++ b/src/Summoner/Project.hs
@@ -23,6 +23,7 @@ import Summoner.Source (fetchSource)
 import Summoner.Template (createProjectTemplate)
 import Summoner.Text (intercalateMap, packageToModule)
 import Summoner.Tree (showTree, traverseTree)
+import qualified Data.List.NonEmpty as NE
 
 -- | Generate the project.
 generateProject :: Text -> Config -> IO ()
@@ -71,7 +72,7 @@ generateProject projectName Config{..} = do
     let settingsWarnings = cWarnings
 
     putTextLn $ "The project will be created with the latest resolver for default GHC-" <> showGhcVer defaultGHC
-    settingsTestedVersions <- sortNub . (defaultGHC :) <$> case cGhcVer of
+    settingsTestedVersions <- NE.sort . NE.nub . (defaultGHC :|) <$> case cGhcVer of
         [] -> do
             putTextLn "Additionally you can specify versions of GHC to test with (space-separated): "
             infoMessage $ "Supported by 'summoner' GHCs: " <> intercalateMap " " showGhcVer universe

--- a/src/Summoner/Settings.hs
+++ b/src/Summoner/Settings.hs
@@ -30,7 +30,7 @@ data Settings = Settings
     , settingsIsExe          :: !Bool   -- ^ is executable
     , settingsTest           :: !Bool   -- ^ add tests
     , settingsBench          :: !Bool   -- ^ add benchmarks
-    , settingsTestedVersions :: ![GhcVer]  -- ^ ghc versions
+    , settingsTestedVersions :: !(NonEmpty GhcVer)  -- ^ ghc versions
     , settingsBase           :: !Text -- ^ Base library to use
     , settingsPrelude        :: !(Maybe CustomPrelude)  -- ^ custom prelude to be used
     , settingsExtensions     :: ![Text] -- ^ default extensions

--- a/src/Summoner/Template.hs
+++ b/src/Summoner/Template.hs
@@ -25,7 +25,7 @@ createProjectTemplate settings@Settings{..} = Dir (toString settingsRepo) $ conc
   where
     cabal, stack :: [TreeFs]
     cabal   = [cabalFile settings]
-    stack   = memptyIfFalse settingsStack $ stackFiles settings  -- TODO: write more elegant
+    stack   = stackFiles settings
     haskell = haskellFiles settings
     docs    = docFiles settings
     gitHub  = gitHubFiles settings

--- a/src/Summoner/Template/GitHub.hs
+++ b/src/Summoner/Template/GitHub.hs
@@ -86,10 +86,10 @@ gitHubFiles Settings{..} =
     travisYml :: Text
     travisYml =
         let travisStackMtr = memptyIfFalse settingsStack $
-                tconcatMap travisStackMatrixItem (delete defaultGHC settingsTestedVersions)
+                tconcatMap travisStackMatrixItem (delete defaultGHC (toList settingsTestedVersions))
                     <> travisStackMatrixDefaultItem
             travisCabalMtr = memptyIfFalse settingsCabal $
-                tconcatMap travisCabalMatrixItem settingsTestedVersions
+                tconcatMap travisCabalMatrixItem (toList settingsTestedVersions)
             installAndScript =
                 if settingsCabal
                 then if settingsStack

--- a/src/Summoner/Template/Stack.hs
+++ b/src/Summoner/Template/Stack.hs
@@ -12,7 +12,7 @@ import Summoner.Tree (TreeFs (..))
 
 
 stackFiles :: Settings -> [TreeFs]
-stackFiles Settings{..} = map createStackYaml settingsTestedVersions
+stackFiles Settings{..} = memptyIfFalse settingsStack $ toListMap createStackYaml settingsTestedVersions
  where
     -- create @stack.yaml@ file with LTS corresponding to specified ghc version
     createStackYaml :: GhcVer -> TreeFs

--- a/src/Summoner/Text.hs
+++ b/src/Summoner/Text.hs
@@ -15,8 +15,8 @@ packageToModule = tconcatMap headToUpper . T.splitOn "-"
 
 -- | Converts every element of list into 'Text' and then joins every element
 -- into single 'Text' like 'T.intercalate'.
-intercalateMap :: Text -> (a -> Text) -> [a] -> Text
-intercalateMap between showT = T.intercalate between . map showT
+intercalateMap :: Foldable t => Text -> (a -> Text) -> t a -> Text
+intercalateMap between showT = T.intercalate between . toListMap showT
 
 headToUpper :: Text -> Text
 headToUpper t = case T.uncons t of


### PR DESCRIPTION
Resolves #179 
I would love feedback on whether this is idiomatic use of the `NonEmpty` data type. While the code builds and the tests pass, there is a lot of conversion from `NonEmpty` to a list via `toList`. I am wondering if I am missing the forest for the trees here. 

`memptyIfFalse` requires a list since `NonEmpty` does not have a `Monoid` instance; `T.concat` requires a list as well; the only area where I made the function a bit more general is in `intercalateMap`, where we take any instance of `Traversable`, instead of hard-coding the list type. We still need to convert it to a list because we use `T.concat`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/summoner/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
- [ ] I changed code related to the generated project.
  - [ ] I created a new project using `summoner` and I checked that this specific feature is working as expected.
