### PR TITLE
[#189] Add tconcatMap to Summoner.Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   Introduce pull request template.
 * [#125](https://github.com/kowainik/summoner/issues/125):
   Split `Summoner.Template` into multiple modules.
+* [#189](https://github.com/kowainik/summoner/issues/189):
+  Add a `tconcatMap` function to `Summoner.Text`
 
 1.1.0.1
 =======

--- a/src/Summoner/Template/GitHub.hs
+++ b/src/Summoner/Template/GitHub.hs
@@ -11,9 +11,8 @@ import NeatInterpolation (text)
 import Summoner.Default (defaultGHC)
 import Summoner.GhcVer (GhcVer (..), showGhcVer)
 import Summoner.Settings (Settings (..))
+import Summoner.Text (tconcatMap)
 import Summoner.Tree (TreeFs (..))
-
-import qualified Data.Text as T
 
 
 gitHubFiles :: Settings -> [TreeFs]
@@ -87,10 +86,10 @@ gitHubFiles Settings{..} =
     travisYml :: Text
     travisYml =
         let travisStackMtr = memptyIfFalse settingsStack $
-                T.concat (map travisStackMatrixItem $ delete defaultGHC settingsTestedVersions)
+                tconcatMap travisStackMatrixItem (delete defaultGHC settingsTestedVersions)
                     <> travisStackMatrixDefaultItem
             travisCabalMtr = memptyIfFalse settingsCabal $
-                T.concat $ map travisCabalMatrixItem settingsTestedVersions
+                tconcatMap travisCabalMatrixItem settingsTestedVersions
             installAndScript =
                 if settingsCabal
                 then if settingsStack

--- a/src/Summoner/Text.hs
+++ b/src/Summoner/Text.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 -- | Creates module name from the name of the package
 -- Ex: @my-lovely-project@ — @MyLovelyProject@
 packageToModule :: Text -> Text
-packageToModule = T.concat . map headToUpper . T.splitOn "-"
+packageToModule = tconcatMap headToUpper . T.splitOn "-"
 
 -- | Converts every element of list into 'Text' and then joins every element
 -- into single 'Text' like 'T.intercalate'.

--- a/src/Summoner/Text.hs
+++ b/src/Summoner/Text.hs
@@ -2,6 +2,7 @@ module Summoner.Text
        ( packageToModule
        , intercalateMap
        , headToUpper
+       , tconcatMap
        ) where
 
 import qualified Data.Char as C
@@ -21,3 +22,7 @@ headToUpper :: Text -> Text
 headToUpper t = case T.uncons t of
     Nothing      -> ""
     Just (x, xs) -> T.cons (C.toUpper x) xs
+
+-- | Convert every element of a list into text, and squash the results
+tconcatMap :: (a -> Text) -> [a] -> Text
+tconcatMap f = T.concat . map f


### PR DESCRIPTION
Add a `tconcatMap` function, and replace
usages of `T.concat` and `map` in other places.

Resolves #189

I didn't find that many usages to be refactored, but this should be pretty useful in the future.

## Checklist:

- [X] I've updated the [CHANGELOG](https://github.com/kowainik/summoner/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [X] All new and existing tests pass.
- [X] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [X] I've used the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [X] My change requires the documentation updates.
  - [X] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
- [ ] I changed code related to the generated project.
  - [ ] I created a new project using `summoner` and I checked that this specific feature is working as expected.
