### PR TITLE
[ci skip] fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ $ source <(summon --bash-completion-script `which summon`)
 ```
 
 After that, you can call `summon` with the required command. To create a
-project, use `summon new` command specifying the prefered CLI options, follow
+project, use `summon new` command specifying the preferred CLI options, follow
 the instructions during the interactive process of the project creation, and a
-new project would be created in a subfolder as well as a repository under your
+new project would be created in a sub folder as well as a repository under your
 GitHub account (if requested).
 
 ### Usage
@@ -113,11 +113,11 @@ Here is the list of the options that could be configured for your needs:
 * `stylish.*` — `stylish.file` to provide the absolute file path to the
   `.stylish-haskell.yaml` file to use in the project. `stylish.url` to provide
   the link to the `.stylish-haskell.yaml` file to use in the project. In case of
-  the absense or wrong path/link no `.stylish-haskell.yaml` file is created.
+  the absence or wrong path/link no `.stylish-haskell.yaml` file is created.
 * `contributing.*` — `contributing.file` to provide the absolute file path to the
   `CONTRIBUTING.md` file to use in the project. `contributing.url` to provide
   the link to the `CONTRIBUTING.md` file to use in the project. In case of
-  the absense or wrong path/link no `CONTRIBUTING` file is created.
+  the absence or wrong path/link no `CONTRIBUTING` file is created.
 
 ###### Custom prelude options
 


### PR DESCRIPTION
## Summary

- Fix typos in README.md

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] ~I've updated the [CHANGELOG](https://github.com/kowainik/summoner/blob/master/CHANGELOG.md) with the short description of my latest changes.~
- [x] All new and existing tests pass.
- [ ] ~I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).~
- [ ] ~I've used the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).~
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.
- [ ] ~I changed code related to the generated project.~
  - [ ] ~I created a new project using `summoner` and I checked that this specific feature is working as expected.~
