### PR TITLE
[#199]   Add `None` license with no `LICENSE` file generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   the generated Travis file.
 * [#142](https://github.com/kowainik/summoner/issues/142):
   Add version bounds to `base` in the generated `.cabal` file.
+* [#199](https://github.com/kowainik/summoner/issues/199):
+  Add `None` license with no `LICENSE` file generation.
+  Add licenses short descriptions text during the interactive mode.
+  Patch `summon show license` command to show short description about
+  each license.
 
 1.1.0.1
 =======

--- a/src/Summoner/CLI.hs
+++ b/src/Summoner/CLI.hs
@@ -25,7 +25,8 @@ import Summoner.Config (ConfigP (..), PartialConfig, defaultConfig, finalise, lo
 import Summoner.Decision (Decision (..))
 import Summoner.Default (defaultConfigFile)
 import Summoner.GhcVer (GhcVer, showGhcVer)
-import Summoner.License (License (..), LicenseName (..), fetchLicense, parseLicenseName)
+import Summoner.License (License (..), LicenseName (..), fetchLicense, licenseShortDesc,
+                         parseLicenseName)
 import Summoner.Project (generateProject)
 import Summoner.Settings (CustomPrelude (..))
 import Summoner.Validation (Validation (..))
@@ -50,7 +51,7 @@ runShow = \case
         -- show list of all available GHC versions
         GhcList -> showBulletList @GhcVer showGhcVer (reverse universe)
         -- show a list of all available licenses
-        LicenseList Nothing -> showBulletList @LicenseName show universe
+        LicenseList Nothing -> showBulletList @LicenseName showDesc universe
         -- show a specific license
         LicenseList (Just name) ->
             case parseLicenseName (toText name) of
@@ -65,6 +66,9 @@ runShow = \case
   where
     showBulletList :: (a -> Text) -> [a] -> IO ()
     showBulletList showT = mapM_ (infoMessage . T.append "➤ " . showT)
+
+    showDesc :: LicenseName -> Text
+    showDesc l = show l <> ": " <> licenseShortDesc l
 
 runNew :: NewOpts -> IO ()
 runNew NewOpts{..} = do

--- a/src/Summoner/License.hs
+++ b/src/Summoner/License.hs
@@ -1,10 +1,12 @@
 module Summoner.License
        ( LicenseName(..)
        , License(..)
+       , cabalLicense
        , customizeLicense
        , githubLicenseQueryNames
        , parseLicenseName
        , fetchLicense
+       , licenseShortDesc
        ) where
 
 import Data.Aeson (FromJSON (..), decodeStrict, withObject, (.:))
@@ -29,6 +31,7 @@ data LicenseName
     | AGPL3
     | Apache20
     | MPL20
+    | None
     deriving (Eq, Ord, Enum, Bounded, Generic)
 
 instance Show LicenseName where
@@ -42,12 +45,18 @@ instance Show LicenseName where
     show AGPL3    = "AGPL-3"
     show Apache20 = "Apache-2.0"
     show MPL20    = "MPL-2.0"
+    show None     = "None"
 
 newtype License = License { unLicense :: Text }
     deriving (IsString, Show, Generic)
 
 instance FromJSON License where
     parseJSON = withObject "License" $ \o -> License <$> o .: "body"
+
+-- | As it will be shown in @cabal@ file.
+cabalLicense :: LicenseName -> Text
+cabalLicense None = "AllRightsReserved"
+cabalLicense l    = show l
 
 githubLicenseQueryNames :: LicenseName -> Text
 githubLicenseQueryNames = \case
@@ -61,6 +70,7 @@ githubLicenseQueryNames = \case
     AGPL3    -> "agpl-3.0"
     Apache20 -> "apache-2.0"
     MPL20    -> "mpl-2.0"
+    None     -> "none"
 
 parseLicenseName :: Text -> Maybe LicenseName
 parseLicenseName = inverseMap show
@@ -78,8 +88,26 @@ customizeLicense l license@(License licenseText) nm year
         in  beforeY <> year <> beforeN <> nm <> afterN
 
 fetchLicense :: LicenseName -> IO License
+fetchLicense None = pure $ License $ licenseShortDesc None
 fetchLicense name = do
     let licenseLink = "https://api.github.com/licenses/" <> githubLicenseQueryNames name
     licenseJson <- readProcess
         "curl" [ toString licenseLink, "-H", "Accept: application/vnd.github.drax-preview+json"] ""
     pure $ fromMaybe (error "Broken predefined license list") (decodeStrict $ pack licenseJson)
+
+-- | Show short information for the 'LicenseName'.
+licenseShortDesc :: LicenseName -> Text
+licenseShortDesc = \case
+    MIT      -> "MIT license"
+    BSD2     -> "2-clause BSD license"
+    BSD3     -> "3-clause BSD license"
+    GPL2     -> "GNU General Public License, version 2"
+    GPL3     -> "GNU General Public License, version 3"
+    LGPL21   -> "GNU Lesser General Public License, version 2.1"
+    LGPL3    -> "GNU Lesser General Public License, version 3"
+    AGPL3    -> "GNU Affero General Public License, version 3"
+    Apache20 -> "Apache License, version 2.0"
+    MPL20    -> "Mozilla Public License, version 2.0."
+    None     -> "License file won't be added. Explicitly 'All Rights Reserved', eg \
+        \for proprietary software. The package may not be legally modified or \
+        \redistributed by anyone but the rightsholder"

--- a/src/Summoner/Project.hs
+++ b/src/Summoner/Project.hs
@@ -6,7 +6,6 @@ module Summoner.Project
        ( generateProject
        ) where
 
-import Data.Text (unlines)
 import NeatInterpolation (text)
 import System.Directory (setCurrentDirectory)
 

--- a/src/Summoner/Project.hs
+++ b/src/Summoner/Project.hs
@@ -6,6 +6,7 @@ module Summoner.Project
        ( generateProject
        ) where
 
+import Data.Text (unlines)
 import NeatInterpolation (text)
 import System.Directory (setCurrentDirectory)
 
@@ -14,7 +15,8 @@ import Summoner.Config (Config, ConfigP (..))
 import Summoner.Decision (Decision (..), decisionToBool)
 import Summoner.Default (currentYear, defaultGHC)
 import Summoner.GhcVer (parseGhcVer, showGhcVer)
-import Summoner.License (customizeLicense, fetchLicense, parseLicenseName)
+import Summoner.License (LicenseName, customizeLicense, fetchLicense, licenseShortDesc,
+                         parseLicenseName)
 import Summoner.Process ()
 import Summoner.Question (checkUniqueName, choose, chooseYesNo, falseMessage, query, queryDef,
                           queryManyRepeatOnFail, targetMessageWithText, trueMessage)
@@ -39,6 +41,7 @@ generateProject noUpload projectName Config{..} = do
     putText categoryText
     settingsCategories <- query "Category: "
 
+    putText licenseText
     settingsLicenseName  <- choose parseLicenseName "License: " $ ordNub (cLicense : universe)
 
     -- License creation
@@ -88,7 +91,7 @@ generateProject noUpload projectName Config{..} = do
     let settings = Settings{..}
 
     createProjectDirectory settings
-    -- Create github repository, commit, optionally push and make it private 
+    -- Create github repository, commit, optionally push and make it private
     when settingsGitHub $ doGithubCommands settings settingsPrivat
 
  where
@@ -116,6 +119,7 @@ generateProject noUpload projectName Config{..} = do
                     ++ ["-p" | private]  -- Create private repository if asked so
              -- Upload repository to GitHub.
             "git" ["push", "-u", "origin", "master"]
+
     categoryText :: Text
     categoryText =
         [text|
@@ -135,6 +139,14 @@ generateProject noUpload projectName Config{..} = do
           * Utility
 
         |]
+
+    licenseText :: Text
+    licenseText = "List of licenses to choose from:\n\n"
+        <> unlines (map showShort $ universe @LicenseName)
+        <> "\n"
+      where
+        showShort :: LicenseName -> Text
+        showShort l = "  * " <> show l <> ": " <> licenseShortDesc l
 
     getPrelude :: IO (Maybe CustomPrelude)
     getPrelude = case cPrelude of

--- a/src/Summoner/Template/Cabal.hs
+++ b/src/Summoner/Template/Cabal.hs
@@ -7,6 +7,7 @@ module Summoner.Template.Cabal
 import NeatInterpolation (text)
 
 import Summoner.GhcVer (GhcVer (..), cabalBaseVersions, showGhcVer)
+import Summoner.License (cabalLicense)
 import Summoner.Settings (CustomPrelude (..), Settings (..))
 import Summoner.Text (intercalateMap, packageToModule)
 import Summoner.Tree (TreeFs (..))
@@ -29,34 +30,34 @@ cabalFile Settings{..} = File (toString settingsRepo ++ ".cabal") cabalFileConte
 
     -- TODO: do something to not have empty lines
     cabalHeader :: Text
-    cabalHeader =
-        [text|
-        cabal-version:       2.0
-        name:                $settingsRepo
-        version:             0.0.0
-        synopsis:            $settingsDescription
-        description:         $settingsDescription
-        $githubHomepage
-        $githubBugReports
-        license:             $licenseName
-        license-file:        LICENSE
-        author:              $settingsFullName
-        maintainer:          $settingsEmail
-        copyright:           $settingsYear $settingsFullName
-        category:            $settingsCategories
-        build-type:          Simple
-        extra-doc-files:     README.md
-                           , CHANGELOG.md
-        tested-with:         $testedGhcs
-        |]
+    cabalHeader = T.unlines $
+        [ "cabal-version:       2.0"
+        , "name:                " <> settingsRepo
+        , "version:             0.0.0"
+        , "synopsis:            " <> settingsDescription
+        , "description:         " <> settingsDescription
+        ] ++
+        [ githubHomepage   | settingsGitHub ] ++
+        [ githubBugReports | settingsGitHub ] ++
+        ( "license:             " <> licenseName) :
+        [ "license-file:        LICENSE" | settingsGitHub] ++
+        [ "author:              " <> settingsFullName
+        , "maintainer:          " <> settingsEmail
+        , "copyright:           " <> settingsYear <> " " <> settingsFullName
+        , "category:            " <> settingsCategories
+        , "build-type:          Simple"
+        , "extra-doc-files:     README.md"
+        , "                   , CHANGELOG.md"
+        , "tested-with:         " <> testedGhcs
+        ]
 
     githubUrl, githubHomepage, githubBugReports :: Text
     githubUrl        = "https://github.com/" <> settingsOwner <> "/" <> settingsRepo
-    githubHomepage   = memptyIfFalse settingsGitHub $ "homepage:            " <> githubUrl
-    githubBugReports = memptyIfFalse settingsGitHub $ "bug-reports:         " <> githubUrl <> "/issues"
+    githubHomepage   = "homepage:            " <> githubUrl
+    githubBugReports = "bug-reports:         " <> githubUrl <> "/issues"
 
     licenseName, libModuleName :: Text
-    licenseName   = show settingsLicenseName
+    licenseName   = cabalLicense settingsLicenseName
     libModuleName = packageToModule settingsRepo
 
     testedGhcs :: Text

--- a/src/Summoner/Template/Cabal.hs
+++ b/src/Summoner/Template/Cabal.hs
@@ -30,15 +30,14 @@ cabalFile Settings{..} = File (toString settingsRepo ++ ".cabal") cabalFileConte
 
     -- TODO: do something to not have empty lines
     cabalHeader :: Text
-    cabalHeader = T.unlines $
+    cabalHeader = unlines $
         [ "cabal-version:       2.0"
         , "name:                " <> settingsRepo
         , "version:             0.0.0"
         , "synopsis:            " <> settingsDescription
-        , "description:         " <> settingsDescription
-        ] ++
-        [ githubHomepage   | settingsGitHub ] ++
-        [ githubBugReports | settingsGitHub ] ++
+        , "description:         " <> settingsDescription ] ++
+        [ "homepage:            " <> githubUrl        | settingsGitHub ] ++
+        [ "bug-reports:         " <> githubBugReports | settingsGitHub ] ++
         ( "license:             " <> licenseName) :
         [ "license-file:        LICENSE" | settingsGitHub] ++
         [ "author:              " <> settingsFullName
@@ -51,10 +50,9 @@ cabalFile Settings{..} = File (toString settingsRepo ++ ".cabal") cabalFileConte
         , "tested-with:         " <> testedGhcs
         ]
 
-    githubUrl, githubHomepage, githubBugReports :: Text
+    githubUrl, githubBugReports :: Text
     githubUrl        = "https://github.com/" <> settingsOwner <> "/" <> settingsRepo
-    githubHomepage   = "homepage:            " <> githubUrl
-    githubBugReports = "bug-reports:         " <> githubUrl <> "/issues"
+    githubBugReports = githubUrl <> "/issues"
 
     licenseName, libModuleName :: Text
     licenseName   = cabalLicense settingsLicenseName

--- a/src/Summoner/Template/Doc.hs
+++ b/src/Summoner/Template/Doc.hs
@@ -16,12 +16,12 @@ import qualified Data.Text as T
 docFiles :: Settings -> [TreeFs]
 docFiles Settings{..} =
     [ File "README.md" readme
-    , File "CHANGELOG.md" changelog
-    ] ++ [File "LICENSE" (unLicense settingsLicenseText) | isNotNoneLicense]
-      ++ maybeToList (File "CONTRIBUTING.md" <$> settingsContributing)
+    , File "CHANGELOG.md" changelog ] ++
+    [ File "LICENSE" (unLicense settingsLicenseText) | hasLicense ] ++
+    maybeToList (File "CONTRIBUTING.md" <$> settingsContributing)
   where
-    isNotNoneLicense :: Bool
-    isNotNoneLicense = settingsLicenseName /= None
+    hasLicense :: Bool
+    hasLicense = settingsLicenseName /= None
 
     licenseName :: Text
     licenseName = show settingsLicenseName
@@ -32,7 +32,7 @@ docFiles Settings{..} =
         , ""
         , hackage
         ]
-     ++ [licenseBadge      | isNotNoneLicense]
+     ++ [licenseBadge      | hasLicense]
      ++ [stackLtsBadge     | settingsStack]
      ++ [stackNightlyBadge | settingsStack]
      ++ [travisBadge       | settingsTravis]

--- a/src/Summoner/Template/Doc.hs
+++ b/src/Summoner/Template/Doc.hs
@@ -6,7 +6,7 @@ module Summoner.Template.Doc
 
 import NeatInterpolation (text)
 
-import Summoner.License (License (..))
+import Summoner.License (License (..), LicenseName (None))
 import Summoner.Settings (Settings (..))
 import Summoner.Tree (TreeFs (..))
 
@@ -17,9 +17,12 @@ docFiles :: Settings -> [TreeFs]
 docFiles Settings{..} =
     [ File "README.md" readme
     , File "CHANGELOG.md" changelog
-    , File "LICENSE" $ unLicense settingsLicenseText
-    ] ++ maybeToList (File "CONTRIBUTING.md" <$> settingsContributing)
+    ] ++ [File "LICENSE" (unLicense settingsLicenseText) | isNotNoneLicense]
+      ++ maybeToList (File "CONTRIBUTING.md" <$> settingsContributing)
   where
+    isNotNoneLicense :: Bool
+    isNotNoneLicense = settingsLicenseName /= None
+
     licenseName :: Text
     licenseName = show settingsLicenseName
 
@@ -28,8 +31,8 @@ docFiles Settings{..} =
         [ "# " <> settingsRepo
         , ""
         , hackage
-        , licenseBadge
         ]
+     ++ [licenseBadge      | isNotNoneLicense]
      ++ [stackLtsBadge     | settingsStack]
      ++ [stackNightlyBadge | settingsStack]
      ++ [travisBadge       | settingsTravis]


### PR DESCRIPTION
*  Add licenses short descriptions text during the interactive mode.
*  Patch `summon show license` command to show short description about
  each license.

Resolves #199

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/summoner/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.
- [x] I changed code related to the generated project.
  - [x] I created a new project using `summoner` and I checked that this specific feature is working as expected.
