### PR TITLE
Revert optional project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Available global options:
 
 ```
 Usage:
-  summon new [PROJECT_NAME] [--ignore-config] [--no-upload] [--offline]
+  summon new PROJECT_NAME [--ignore-config] [--no-upload] [--offline]
              [-f|--file FILENAME]
              [--cabal]
              [--stack]

--- a/summoner-cli/CHANGELOG.md
+++ b/summoner-cli/CHANGELOG.md
@@ -5,9 +5,6 @@ The changelog is available [on GitHub][2].
 
 ## Unreleased: 1.2.0
 
-
-* [#243](https://github.com/kowainik/summoner/issues/243):
-  Make project name optional in CLI arguments. Now you can `summon new` to start creating the project.
 * Make `cabal-version: 2.0` default in generated projects.
 * [#11](https://github.com/kowainik/summoner/issues/11):
   Support offline mode.

--- a/summoner-cli/src/Summoner/CLI.hs
+++ b/summoner-cli/src/Summoner/CLI.hs
@@ -164,7 +164,7 @@ data Command
 
 -- | Options parsed with @new@ command
 data NewOpts = NewOpts
-    { newOptsProjectName :: Maybe Text     -- ^ project name
+    { newOptsProjectName :: Text           -- ^ project name
     , newOptsIgnoreFile  :: Bool           -- ^ ignore all config files if 'True'
     , newOptsNoUpload    :: Bool           -- ^ don't upload to github
     , newOptsOffline     :: Bool           -- ^ Offline mode
@@ -231,7 +231,7 @@ licenseText = LicenseList <$> optional
 -- | Parses options of the @new@ command.
 newP :: Parser Command
 newP = do
-    newOptsProjectName <- optional $ strArgument (metavar "PROJECT_NAME")
+    newOptsProjectName <- strArgument (metavar "PROJECT_NAME")
     newOptsIgnoreFile  <- ignoreFileP
     newOptsNoUpload    <- noUploadP
     newOptsOffline     <- offlineP

--- a/summoner-cli/src/Summoner/Project.hs
+++ b/summoner-cli/src/Summoner/Project.hs
@@ -33,12 +33,11 @@ import Summoner.Tree (showBoldTree, traverseTree)
 generateProject
     :: Bool        -- ^ @noUpload@ option (to not upload to @Github@).
     -> Bool        -- ^ @offline@ mode option
-    -> Maybe Text  -- ^ Given project name.
+    -> Text        -- ^ Given project name.
     -> Config      -- ^ Given configurations.
     -> IO ()
-generateProject settingsNoUpload isOffline maybeName Config{..} = do
-    projectName <- whenNothing maybeName (queryNotNull "Project name: ")
-    settingsRepo   <- checkUniqueName projectName
+generateProject settingsNoUpload isOffline projectName Config{..} = do
+    settingsRepo <- checkUniqueName projectName
     -- decide cabal stack or both
     (settingsCabal, settingsStack) <- getCabalStack (cCabal, cStack)
 

--- a/summoner-tui/src/Summoner/Tui/Kit.hs
+++ b/summoner-tui/src/Summoner/Tui/Kit.hs
@@ -221,7 +221,7 @@ finalSettings sk = do
 
 -- | Gets the initial 'SummonKit' from the given 'Config'.
 configToSummonKit
-    :: Maybe Text  -- ^ Given project name
+    :: Text  -- ^ Given project name
     -> Bool    -- ^ @noUpload@ option (to not upload to @Github@).
     -> Bool    -- ^  @offline@ mode option
     -> Maybe FilePath  -- ^ Configuration file used
@@ -234,7 +234,7 @@ configToSummonKit cRepo cNoUpload cOffline cConfigFile Config{..} = SummonKit
         , userEmail    = cEmail
         }
     , summonKitProject = Project
-        { projectRepo     = maybeToMonoid cRepo
+        { projectRepo     = cRepo
         , projectDesc     = defaultDescription
         , projectCategory = ""
         , projectLicense  = if cOffline then None else cLicense


### PR DESCRIPTION
Resolves :computer: 

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [x] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [ ] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [x] Update documentation (README, haddock) if required.
- [ ] Create a new test project using `summoner` and check that the changes work as expected.

*Hint:* Add the `[ci skip]` text to the docs-only related commit's name, so no need to wait for CI to pass.
