### PR TITLE
Note that libtinfo is needed to build summoner-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,10 @@ If you'd like to take part in the development processes, here are a few things t
 * To sum up, [here is the Contributing guide](https://github.com/kowainik/org/blob/master/CONTRIBUTING.md#contributing-to-the-kowainik-repositories) we use across the repositories.
 * This project is contributor-friendly, so be kind to other people working on the project.
 
+### Dependencies [↑](#structure)
+
+On Linux, to build the `summoner-tui` you'll need to have `libtinfo` installed. The easiest way to get this is from your system's package manager and is usually available as the package `libtinfo-dev`.
+
 ### Build [↑](#structure)
 
 To build the project you can use the following commands:


### PR DESCRIPTION
To successfully build `summoner-tui` via `cabal new-build all` you must have the `libtinfo` library installed. Without it the build fails with the following error because the `vty` dependency requires it (on Debian Linux, at least):

```
[21 of 36] Compiling Graphics.Vty.Input.Loop ( src/Graphics/Vty/Input/Loop.hs, dist/build/Graphics/Vty/Input/Loop.o )
<command line>: can't load .so/.DLL for: libtinfo.so (libtinfo.so: cannot open shared object file: No such file or directory)
cabal: Failed to build vty-5.25.1 (which is required by exe:summon-tui from
summoner-tui-0.0.0). See the build log above for details.
```


To summoner maintainers: feel free to tweak wording, placement in file, etc.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [ ] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [ ] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [ ] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [x] Update documentation (README, haddock) if required.
- [ ] Create a new test project using `summoner` and check that the changes work as expected.

*Hint:* Add the `[ci skip]` text to the docs-only related commit's name, so no need to wait for CI to pass.
 
/cc @ChShersh 