### PR TITLE
[#272] [#275] Travis improvements for generated project

### DIFF
--- a/summoner-cli/CHANGELOG.md
+++ b/summoner-cli/CHANGELOG.md
@@ -9,6 +9,13 @@ The changelog is available [on GitHub][2].
   Make GHC-8.6.3 default.
 * [#268](https://github.com/kowainik/summoner/issues/268):
   Simplify process of adding custom prelude in the interactive mode.
+* [#272](https://github.com/kowainik/summoner/issues/272):
+  Simplify Travis config for Cabal.
+* [#275](https://github.com/kowainik/summoner/issues/275):
+  Simplify Travis settings/installation process for Stack.
+* __Important:__ Summoner doesn't add old GHC versions into Travis matrix for
+  Stack. See this Stack issue for reasoning:
+      https://github.com/commercialhaskell/stack/issues/4488
 
 ## 1.2.0 — Nov 30, 2018
 

--- a/summoner-cli/src/Summoner/Default.hs
+++ b/summoner-cli/src/Summoner/Default.hs
@@ -2,6 +2,7 @@
 
 module Summoner.Default
        ( defaultGHC
+       , defaultCabal
        , defaultTomlFile
        , defaultConfigFile
        , defaultDescription
@@ -21,6 +22,10 @@ import Summoner.GhcVer (GhcVer)
 -- | Default GHC version is the latest available.
 defaultGHC :: GhcVer
 defaultGHC = maxBound
+
+-- | Default version of the Cabal.
+defaultCabal :: Text
+defaultCabal = "2.0"
 
 defaultTomlFile :: FilePath
 defaultTomlFile = ".summoner.toml"

--- a/summoner-cli/src/Summoner/GhcVer.hs
+++ b/summoner-cli/src/Summoner/GhcVer.hs
@@ -1,3 +1,7 @@
+{- | Contains data type for GHC versions supported by Summoner
+and some useful functions for manipulation with them.
+-}
+
 module Summoner.GhcVer
        ( GhcVer (..)
        , Pvp (..)
@@ -6,6 +10,8 @@ module Summoner.GhcVer
        , latestLts
        , baseVer
        , cabalBaseVersions
+
+       , oldGhcs
        ) where
 
 import Data.List (maximum, minimum)
@@ -34,6 +40,10 @@ showGhcVer = \case
     Ghc843  -> "8.4.3"
     Ghc844  -> "8.4.4"
     Ghc863  -> "8.6.3"
+
+-- | These are old GHC versions that are not working with default GHC versions when using Stack.
+oldGhcs :: [GhcVer]
+oldGhcs = [minBound .. Ghc802]
 
 parseGhcVer :: Text -> Maybe GhcVer
 parseGhcVer = inverseMap showGhcVer

--- a/summoner-cli/src/Summoner/Template/Cabal.hs
+++ b/summoner-cli/src/Summoner/Template/Cabal.hs
@@ -6,6 +6,7 @@ module Summoner.Template.Cabal
 
 import NeatInterpolation (text)
 
+import Summoner.Default (defaultCabal)
 import Summoner.GhcVer (GhcVer (..), cabalBaseVersions, showGhcVer)
 import Summoner.License (LicenseName (..), cabalLicense)
 import Summoner.Settings (CustomPrelude (..), Settings (..))
@@ -31,7 +32,7 @@ cabalFile Settings{..} = File (toString settingsRepo ++ ".cabal") cabalFileConte
     -- TODO: do something to not have empty lines
     cabalHeader :: Text
     cabalHeader = unlines $
-        [ "cabal-version:       2.0"
+        [ "cabal-version:       " <> defaultCabal
         , "name:                " <> settingsRepo
         , "version:             0.0.0"
         , "synopsis:            " <> settingsDescription

--- a/summoner-cli/src/Summoner/Template/GitHub.hs
+++ b/summoner-cli/src/Summoner/Template/GitHub.hs
@@ -91,6 +91,8 @@ gitHubFiles Settings{..} =
         git:
           depth: 5
 
+        cabal: "head"
+
         cache:
           directories:
           $travisCabalCache
@@ -130,13 +132,6 @@ gitHubFiles Settings{..} =
         - ghc: ${ghcV}
           env: GHCVER='${ghcV}' CABALVER='head'
           os: linux
-          addons:
-            apt:
-              sources:
-              - hvr-ghc
-              packages:
-              - ghc-${ghcV}
-              - cabal-install-head
         |]
 
     travisStackMtr :: Text

--- a/summoner-cli/test/golden/fullProject/.travis.yml
+++ b/summoner-cli/test/golden/fullProject/.travis.yml
@@ -19,9 +19,6 @@ matrix:
   - ghc: 8.4.4
   - ghc: 8.6.3
   
-  - ghc: 8.0.2
-    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.0.2.yaml"
-  
   - ghc: 8.2.2
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.2.2.yaml"
   
@@ -47,7 +44,7 @@ script:
     if [ -z "$STACK_YAML" ]; then
        cabal new-test
     else
-      stack build --test --bench --no-run-benchmarks --no-terminal --ghc-options=-Werror
+      stack build --system-ghc --test --bench --no-run-benchmarks --no-terminal --ghc-options=-Werror
     fi
 
   # HLint check

--- a/summoner-cli/test/golden/fullProject/.travis.yml
+++ b/summoner-cli/test/golden/fullProject/.travis.yml
@@ -4,6 +4,8 @@ language: haskell
 git:
   depth: 5
 
+cabal: "head"
+
 cache:
   directories:
   - "$HOME/.cabal"
@@ -16,46 +18,18 @@ matrix:
   - ghc: 8.0.2
     env: GHCVER='8.0.2' CABALVER='head'
     os: linux
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-8.0.2
-        - cabal-install-head
   
   - ghc: 8.2.2
     env: GHCVER='8.2.2' CABALVER='head'
     os: linux
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-8.2.2
-        - cabal-install-head
   
   - ghc: 8.4.4
     env: GHCVER='8.4.4' CABALVER='head'
     os: linux
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-8.4.4
-        - cabal-install-head
   
   - ghc: 8.6.3
     env: GHCVER='8.6.3' CABALVER='head'
     os: linux
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-8.6.3
-        - cabal-install-head
   
   - ghc: 8.0.2
     env: GHCVER='8.0.2' STACK_YAML="$TRAVIS_BUILD_DIR/stack-$GHCVER.yaml"

--- a/summoner-cli/test/golden/fullProject/.travis.yml
+++ b/summoner-cli/test/golden/fullProject/.travis.yml
@@ -4,80 +4,42 @@ language: haskell
 git:
   depth: 5
 
-cabal: "head"
+cabal: "2.0"
 
 cache:
   directories:
-  - "$HOME/.cabal"
+  - "$HOME/.cabal/store"
   - "$HOME/.stack"
   - "$TRAVIS_BUILD_DIR/.stack-work"
 
 matrix:
   include:
+  - ghc: 8.0.2
+  - ghc: 8.2.2
+  - ghc: 8.4.4
+  - ghc: 8.6.3
   
   - ghc: 8.0.2
-    env: GHCVER='8.0.2' CABALVER='head'
-    os: linux
+    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.0.2.yaml"
   
   - ghc: 8.2.2
-    env: GHCVER='8.2.2' CABALVER='head'
-    os: linux
+    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.2.2.yaml"
   
   - ghc: 8.4.4
-    env: GHCVER='8.4.4' CABALVER='head'
-    os: linux
+    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.4.4.yaml"
   
   - ghc: 8.6.3
-    env: GHCVER='8.6.3' CABALVER='head'
-    os: linux
-  
-  - ghc: 8.0.2
-    env: GHCVER='8.0.2' STACK_YAML="$TRAVIS_BUILD_DIR/stack-$GHCVER.yaml"
-    os: linux
-    addons:
-      apt:
-        packages:
-        - libgmp-dev
-  
-  - ghc: 8.2.2
-    env: GHCVER='8.2.2' STACK_YAML="$TRAVIS_BUILD_DIR/stack-$GHCVER.yaml"
-    os: linux
-    addons:
-      apt:
-        packages:
-        - libgmp-dev
-  
-  - ghc: 8.4.4
-    env: GHCVER='8.4.4' STACK_YAML="$TRAVIS_BUILD_DIR/stack-$GHCVER.yaml"
-    os: linux
-    addons:
-      apt:
-        packages:
-        - libgmp-dev
-  
-  - ghc: 8.6.3
-    env: GHCVER='8.6.3' STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
-    os: linux
-    addons:
-      apt:
-        packages:
-        - libgmp-dev
+    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:
   - |
     if [ -z "$STACK_YAML" ]; then
-      export PATH="/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH"
-      echo $PATH
       cabal new-update
       cabal new-build --enable-tests --enable-benchmarks
     else
-      mkdir -p ~/.local/bin
-      export PATH="$HOME/.local/bin:$PATH"
-      travis_retry curl -L 'https://www.stackage.org/stack/linux-x86_64' | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+      curl -sSL https://get.haskellstack.org/ | sh
       stack --version
-      stack setup --no-terminal --install-cabal 2.2.0.1
-      stack ghc -- --version
-      stack build --only-dependencies --no-terminal
+      stack build --system-ghc --test --no-run-tests
     fi
 
 script:
@@ -88,6 +50,7 @@ script:
       stack build --test --bench --no-run-benchmarks --no-terminal --ghc-options=-Werror
     fi
 
+  # HLint check
   - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .
 
 notifications:


### PR DESCRIPTION
It doesn't work for Stack when the version of GHC is 8.0.2 because it uses old Stack, not the one that is configured, but it shouldn't work with the old version of Cabal (manually writing `stack setup --no-terminal --install-cabal 2.2.0.1` doesn't help as well.

__UPD:__ We decided not to add old GHC into Stack Travis matrix.

Resolves #272 
Resolves #275 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [x] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [ ] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [ ] Update documentation (README, haddock) if required.
- [x] Create a new test project using `summoner` and check that the changes work as expected.