### PR TITLE
[#285] Implement 'summon script' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
     if [ -z "$STACK_YAML" ]; then
       cabal new-test all
     else
-      stack test --no-terminal
+      stack test --system-ghc --no-terminal
     fi
   - curl https://raw.githubusercontent.com/kowainik/relude/988bbdd3a09df1159917012933780523644880e5/.hlint.yaml -o .hlint-relude.yaml
   - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint -h .hlint-relude.yaml summoner-cli/src/ summoner-cli/test/ summoner-tui/src/
@@ -63,8 +63,8 @@ after_success:
   - |
     if [ "$DEPLOY" = "yes" ]; then
       echo "Deploy triggered!"
-      mv "$(stack path --local-install-root)/bin/summon"     "summon-cli-${TRAVIS_OS_NAME}"
-      mv "$(stack path --local-install-root)/bin/summon-tui" "summon-tui-${TRAVIS_OS_NAME}"
+      mv "$(stack path --system-ghc --local-install-root)/bin/summon"     "summon-cli-${TRAVIS_OS_NAME}"
+      mv "$(stack path --system-ghc --local-install-root)/bin/summon-tui" "summon-tui-${TRAVIS_OS_NAME}"
       chmod +x "summon-cli-${TRAVIS_OS_NAME}"
       chmod +x "summon-tui-${TRAVIS_OS_NAME}"
       git tag "$(date +'%Y%m%d%H%M%S')"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.1
+resolver: lts-13.9
 
 packages:
   - summoner-cli/

--- a/summoner-cli/CHANGELOG.md
+++ b/summoner-cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 `summoner` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
-## Unreleased
+## Unreleased: 1.3.0
 
 * [#151](https://github.com/kowainik/summoner/issues/151):
   Make GHC-8.6.3 default.
@@ -20,6 +20,8 @@ The changelog is available [on GitHub][2].
   Bump up to `tomland-1.0.0`
 * [#282](https://github.com/kowainik/summoner/issues/282):
   Allow users to extend the .gitignore file.
+* [#285](https://github.com/kowainik/summoner/issues/285):
+  Implement `summon script` command.
 
 ## 1.2.0 — Nov 30, 2018
 

--- a/summoner-cli/src/Summoner/GhcVer.hs
+++ b/summoner-cli/src/Summoner/GhcVer.hs
@@ -56,8 +56,8 @@ latestLts = \case
     Ghc802  -> "9.21"
     Ghc822  -> "11.22"
     Ghc843  -> "12.14"
-    Ghc844  -> "12.25"
-    Ghc863  -> "13.0"
+    Ghc844  -> "12.26"
+    Ghc863  -> "13.9"
 
 -- | Represents PVP versioning (4 numbers).
 data Pvp = Pvp

--- a/summoner-cli/src/Summoner/Settings.hs
+++ b/summoner-cli/src/Summoner/Settings.hs
@@ -1,7 +1,12 @@
 module Summoner.Settings
        ( Settings (..)
+
        , CustomPrelude (..)
        , customPreludeT
+
+       , Tool (..)
+       , showTool
+       , parseTool
        ) where
 
 import Toml (TomlCodec, (.=))
@@ -53,3 +58,19 @@ data Settings = Settings
     , settingsContributing   :: !(Maybe Text) -- ^ @CONTRIBUTING.md@ file
     , settingsNoUpload       :: !Bool  -- ^ do not upload to GitHub
     } deriving (Show)
+
+-- | Enum for supported build tools.
+data Tool
+    = Cabal
+    | Stack
+    deriving (Show, Eq, Enum, Bounded)
+
+-- | Show 'Tool' in lowercase.
+showTool :: Tool -> Text
+showTool = \case
+    Cabal -> "cabal"
+    Stack -> "stack"
+
+-- | Parse 'Tool' from string. Inverse of 'showTool'.
+parseTool :: Text -> Maybe Tool
+parseTool = inverseMap showTool

--- a/summoner-cli/src/Summoner/Template/Script.hs
+++ b/summoner-cli/src/Summoner/Template/Script.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | File templates for @cabal@ and @stack@ scripts.
+
+module Summoner.Template.Script
+       ( scriptFile
+       ) where
+
+import NeatInterpolation (text)
+
+import Summoner.GhcVer (GhcVer, baseVer, latestLts)
+import Summoner.Settings (Tool (..))
+
+
+-- | 'Text' content for a single script file.
+scriptFile :: GhcVer -> Tool -> Text
+scriptFile ghcVer = \case
+    Cabal ->
+        [text|
+        #!/usr/bin/env cabal
+        {- cabal:
+        build-depends:
+          , base ^>= $baseVersion
+        -}
+
+        main :: IO ()
+        main = putStrLn "Hello, World!"
+        |]
+    Stack ->
+        [text|
+        #!/usr/bin/env stack
+        {- stack
+          --resolver lts-${ltsVersion}
+          script
+          --package base
+        -}
+
+        main :: IO ()
+        main = putStrLn "Hello, World!"
+        |]
+  where
+    baseVersion, ltsVersion :: Text
+    baseVersion = baseVer ghcVer
+    ltsVersion  = latestLts ghcVer

--- a/summoner-cli/summoner.cabal
+++ b/summoner-cli/summoner.cabal
@@ -45,6 +45,7 @@ library
                            Summoner.Template.Doc
                            Summoner.Template.GitHub
                            Summoner.Template.Haskell
+                           Summoner.Template.Script
                            Summoner.Template.Stack
                          Summoner.Text
                          Summoner.Tree
@@ -55,7 +56,7 @@ library
 
   build-depends:       base-noprelude >= 4.10 && < 4.13
                      , aeson >= 1.2.4.0 && < 1.5
-                     , ansi-terminal ^>= 0.8.0.4
+                     , ansi-terminal >= 0.8 && < 0.10
                      , bytestring ^>= 0.10.8.2
                      , directory ^>= 1.3.0.2
                      , filepath ^>= 1.4.1.2
@@ -115,6 +116,7 @@ test-suite summoner-test
   main-is:             Spec.hs
   other-modules:       Test.DecisionSpec
                        Test.Golden
+                       Test.Script
                        Test.TomlSpec
                        Test.QuestionSpec
                        Prelude

--- a/summoner-cli/test/Spec.hs
+++ b/summoner-cli/test/Spec.hs
@@ -6,6 +6,7 @@ import Test.Hspec (hspec)
 import Test.DecisionSpec (decisionMonoidMempty, decisionSemigroupAssoc)
 import Test.Golden (goldenSpec)
 import Test.QuestionSpec (yesNoPromptSpec)
+import Test.Script (scriptSpec)
 import Test.TomlSpec (tomlProp)
 
 
@@ -13,6 +14,7 @@ main :: IO ()
 main = do
     hspec $ do
         yesNoPromptSpec
+        scriptSpec
         goldenSpec
     ifM (checkParallel hedgehogTests) exitSuccess exitFailure
 

--- a/summoner-cli/test/Test/Script.hs
+++ b/summoner-cli/test/Test/Script.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Script
+       ( scriptSpec
+       ) where
+
+import NeatInterpolation (text)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Summoner.GhcVer (GhcVer (..))
+import Summoner.Settings (Tool (..))
+import Summoner.Template.Script (scriptFile)
+
+
+scriptSpec :: Spec
+scriptSpec = describe "script golden tests" $ do
+    it "correctly creates cabal script" $
+        scriptFile Ghc844 Cabal `shouldBe` cabalScript
+    it "correctly creates stack script" $
+        scriptFile Ghc863 Stack `shouldBe` stackScript
+
+cabalScript :: Text
+cabalScript = [text|
+#!/usr/bin/env cabal
+{- cabal:
+build-depends:
+  , base ^>= 4.11.1.0
+-}
+
+main :: IO ()
+main = putStrLn "Hello, World!"
+|]
+
+stackScript :: Text
+stackScript = [text|
+#!/usr/bin/env stack
+{- stack
+  --resolver lts-13.9
+  script
+  --package base
+-}
+
+main :: IO ()
+main = putStrLn "Hello, World!"
+|]

--- a/summoner-cli/test/golden/fullProject/.travis.yml
+++ b/summoner-cli/test/golden/fullProject/.travis.yml
@@ -4,7 +4,7 @@ language: haskell
 git:
   depth: 5
 
-cabal: "2.0"
+cabal: "2.4"
 
 cache:
   directories:
@@ -31,20 +31,22 @@ matrix:
 install:
   - |
     if [ -z "$STACK_YAML" ]; then
+      ghc --version
+      cabal --version
       cabal new-update
       cabal new-build --enable-tests --enable-benchmarks
     else
       curl -sSL https://get.haskellstack.org/ | sh
       stack --version
-      stack build --system-ghc --test --no-run-tests
+      stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --ghc-options=-Werror
     fi
 
 script:
   - |
     if [ -z "$STACK_YAML" ]; then
-       cabal new-test
+       cabal new-test --enable-tests
     else
-      stack build --system-ghc --test --bench --no-run-benchmarks --no-terminal --ghc-options=-Werror
+      stack test --system-ghc
     fi
 
   # HLint check

--- a/summoner-cli/test/golden/fullProject/stack-8.4.4.yaml
+++ b/summoner-cli/test/golden/fullProject/stack-8.4.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.25
+resolver: lts-12.26
 
 extra-deps: [base-noprelude-4.11.1.0]
 

--- a/summoner-cli/test/golden/fullProject/stack.yaml
+++ b/summoner-cli/test/golden/fullProject/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.0
+resolver: lts-13.9
 
 extra-deps: [base-noprelude-4.12.0.0]
 

--- a/summoner-tui/src/Summoner/Tui.hs
+++ b/summoner-tui/src/Summoner/Tui.hs
@@ -28,7 +28,7 @@ import Lens.Micro ((.~), (^.))
 import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 
 import Summoner.Ansi (errorMessage, infoMessage)
-import Summoner.CLI (Command (..), NewOpts (..), ShowOpts (..), getFinalConfig, summon)
+import Summoner.CLI (Command (..), NewOpts (..), ShowOpts (..), getFinalConfig, runScript, summon)
 import Summoner.Decision (Decision (..))
 import Summoner.Default (defaultConfigFile)
 import Summoner.GhcVer (showGhcVer)
@@ -54,6 +54,7 @@ summonTui = summon Meta.version runTuiCommand
 runTuiCommand :: Command -> IO ()
 runTuiCommand = \case
     New opts      -> summonTuiNew opts
+    Script opts   -> runScript opts  -- TODO: implement TUI for script command
     ShowInfo opts -> summonTuiShow opts
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #285

Currently support of `script` command for TUI mode does the same as for CLI mode. I think implementing TUI for this command is separate big issue...

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [x] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [x] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [ ] Update documentation (README, haddock) if required.
- [ ] Create a new test project using `summoner` and check that the changes work as expected.

*Hint:* Add the `[ci skip]` text to the docs-only related commit's name, so no need to wait for CI to pass.
