### PR TITLE
Better golden testing using 'tree-diff'

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,37 +1,27 @@
-build: off
+install:
+  # Using '-y' and 'refreshenv' as a workaround to:
+  # https://github.com/haskell/cabal/issues/3687
+  - choco source add -n mistuke -s https://www.myget.org/F/mistuke/api/v2
+  - choco install -y ghc --ignore-dependencies
+  - choco install -y cabal-head -pre
+  - refreshenv
+  # See http://help.appveyor.com/discussions/problems/6312-curl-command-not-found#comment_42195491
+  # NB: Do this after refreshenv, otherwise it will be clobbered!
+  - set PATH=%APPDATA%\cabal\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\msys64\usr\bin;%PATH%
+  - cabal --version
+  - cabal %CABOPTS% new-update
 
-before_test:
-# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
-- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
-
-- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
-- 7z x stack.zip stack.exe
-
-clone_folder: "c:\\stack"
 environment:
   global:
-    STACK_ROOT: "c:\\sr"
+    CABOPTS:  "--store-dir=C:\\SR"
+    # Remove cache, there is no button on the web
+    # https://www.appveyor.com/docs/build-cache/#skipping-cache-operations-for-specific-build
+    APPVEYOR_CACHE_SKIP_RESTORE: true
 
-test_script:
-- stack setup > nul
-# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
-# descriptor
-- echo "" | stack --arch x86_64 --no-terminal build summoner --bench --no-run-benchmarks --test
+cache:
+  - dist-newstyle
+  - "C:\\SR"
 
-# Attempts to deploy on Windows CI
-# - ps: cp "$(./stack.exe path --local-install-root)/bin/summon.exe" summon-cli.exe
-#
-# artifacts:
-#   - path: summon-cli.exe
-#     name: executable
-#
-# deploy:
-#   description: 'Summoner release created by AppVeyor CI'
-#   provider: GitHub
-#   auth_token: '%GitHub_auth_token%'
-#   artifact: executable
-#   draft: false
-#   prerelease: false
-#   on:
-#     branch: master                 # release from master branch only
-#     appveyor_repo_tag: true        # deploy on tag push only
+build_script:
+  - cabal %CABOPTS% new-build --enable-tests all
+  - cabal %CABOPTS% new-test all

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -11,6 +11,7 @@ extra-deps:
   - relude-0.4.0
   - shellmet-0.0.0
   - tomland-1.0.0
+  - tree-diff-0.0.2
   - megaparsec-7.0.4            # needed for tomland-0.5.0
   - parser-combinators-1.0.0    # needed for megaparsec >= 7
   - neat-interpolation-0.3.2.4  # needed because of megaparsec >= 7

--- a/summoner-cli/src/Summoner/Tree.hs
+++ b/summoner-cli/src/Summoner/Tree.hs
@@ -11,12 +11,14 @@ import System.Directory (createDirectoryIfMissing, withCurrentDirectory)
 
 import Summoner.Ansi (boldCode, resetCode)
 
+
 -- | Describes simple structure of filesystem tree.
 data TreeFs
       -- | Name of directory (relative) and its containing entries
     = Dir FilePath [TreeFs]
       -- | File name (relative) and file content
     | File FilePath Text
+    deriving (Generic, Show, Eq, Ord)
 
 -- | Walks through directory tree and write file contents, creating all
 -- intermediate directories.

--- a/summoner-cli/summoner.cabal
+++ b/summoner-cli/summoner.cabal
@@ -121,12 +121,14 @@ test-suite summoner-test
                        Prelude
 
   build-depends:       base-noprelude >= 4.10 && < 4.13
+                     , directory
                      , filepath
                      , hedgehog >= 0.5.3 && < 0.7
                      , hspec >= 2.4.8
                      , neat-interpolation
                      , relude
                      , tomland
+                     , tree-diff ^>= 0.0.2
                      , summoner
 
 
@@ -141,7 +143,8 @@ test-suite summoner-test
                        -Wredundant-constraints
                        -fhide-source-paths
 
-  default-extensions:  OverloadedStrings
+  default-extensions:  LambdaCase
+                       OverloadedStrings
                        RecordWildCards
 
   default-language:    Haskell2010

--- a/summoner-cli/test/Test/Golden.hs
+++ b/summoner-cli/test/Test/Golden.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 {-# LANGUAGE QuasiQuotes #-}
 
 {- | Golden tests for @summoner@.
@@ -17,9 +19,11 @@ module Test.Golden
        ( goldenSpec
        ) where
 
+import Data.TreeDiff (ToExpr, ansiWlEditExprCompact, ediff)
 import NeatInterpolation (text)
-import System.FilePath ((</>))
-import Test.Hspec (Spec, describe, it, shouldReturn)
+import System.Directory (doesDirectoryExist, listDirectory)
+import System.FilePath (takeFileName, (</>))
+import Test.Hspec (Spec, describe, expectationFailure, it)
 
 import Summoner (CustomPrelude (..), GhcVer (..), License (..), LicenseName (..), Settings (..),
                  defaultGHC)
@@ -30,21 +34,32 @@ import Summoner.Tree (TreeFs (..))
 goldenSpec :: Spec
 goldenSpec = describe "golden tests" $ do
     it "correctly creates full project" $
-        checkProject fullProject
+        checkProject "test/golden/fullProject" fullProject
     it "correctly creates small project" $
-        checkProject smallProject
+        checkProject "test/golden/smallProject" smallProject
   where
-    checkProject pr = compareTree "test/golden" (createProjectTemplate pr) `shouldReturn` []
+    checkProject :: FilePath -> Settings -> IO ()
+    checkProject path settings = do
+        goldenFs  <- sortTree <$> readTreeFs path
+        let testFs = sortTree $ createProjectTemplate settings
+        when (goldenFs /= testFs) $ do
+            putTextLn $ show $ ansiWlEditExprCompact $ ediff goldenFs testFs
+            expectationFailure "Golden and scaffolded project don't match"
 
+readTreeFs :: FilePath -> IO TreeFs
+readTreeFs filePath = doesDirectoryExist filePath >>= \case
+    True -> do
+        dirs <- listDirectory filePath
+        Dir (takeFileName filePath) <$> traverse (\dir -> readTreeFs $ filePath </> dir) dirs
+    False -> do
+        content <- readFileText filePath
+        pure $ File (takeFileName filePath) content
 
--- | Returns the list of the files that don't match the golden ones.
-compareTree :: FilePath -> TreeFs -> IO [FilePath]
-compareTree filePath (Dir name children) =
-    foldlM (\l ch -> (l ++) <$> compareTree (filePath </> name) ch) [] children
-compareTree filePath (File name content) = do
-    let curFile = filePath </> name
-    golden <- readFileText curFile
-    pure $ if golden == content then [] else [curFile]
+sortTree :: TreeFs -> TreeFs
+sortTree = \case
+    file@(File _ _) -> file
+    Dir path fs -> Dir path $ sort $ map sortTree fs
+
 
 fullProject :: Settings
 fullProject = Settings
@@ -134,3 +149,7 @@ smallProject = Settings
     , settingsContributing   = Nothing
     , settingsNoUpload       = True
     }
+
+-- Orphan instances
+
+instance ToExpr TreeFs

--- a/summoner-tui/summoner-tui.cabal
+++ b/summoner-tui/summoner-tui.cabal
@@ -25,6 +25,8 @@ source-repository head
   location: git@github.com:kowainik/summoner.git
 
 library
+  if os(windows)
+    buildable: False
   hs-source-dirs:      src
   exposed-modules:     Summoner.Tui
                          Summoner.Tui.Field
@@ -69,6 +71,8 @@ library
   default-language:    Haskell2010
 
 executable summon-tui
+  if os(windows)
+    buildable: False
   hs-source-dirs:      app
   main-is:             Tui.hs
   build-depends:       base >= 4.10 && < 4.13


### PR DESCRIPTION
This PR implements better output of diff in tests when there's mismatch between golden examples and scaffolded by `summoner` project. It uses `tree-diff` library (thanks @phadej for implementing it!).

If there are errors in `fullProject` the output is big. But it's still possible and relatively convenient to find error so it can be fixed easily.