### PR TITLE
[#297] Strip project description in TUI

### DIFF
--- a/summoner-tui/CHANGELOG.md
+++ b/summoner-tui/CHANGELOG.md
@@ -11,6 +11,8 @@ The changelog is available [on GitHub][2].
 * [#280](https://github.com/kowainik/summoner/issues/280):
   AppVeyor CI checkbox is no longer disabled when only `cabal` build tool is
   selected.
+* [#297](https://github.com/kowainik/summoner/issues/297):
+  Strip project description.
 
 ## 0.0.0 — Nov 30, 2018
 

--- a/summoner-tui/src/Summoner/Tui/Kit.hs
+++ b/summoner-tui/src/Summoner/Tui/Kit.hs
@@ -157,7 +157,7 @@ summonKitToSettings :: SummonKit -> Settings
 summonKitToSettings sk = Settings
     { settingsRepo           = T.strip $ sk ^. project . repo
     , settingsOwner          = T.strip $ sk ^. user . owner
-    , settingsDescription    = sk ^. project . desc
+    , settingsDescription    = T.strip $ sk ^. project . desc
     , settingsFullName       = T.strip $ sk ^. user . fullName
     , settingsEmail          = T.strip $ sk ^. user . email
     , settingsYear           = "20!8"


### PR DESCRIPTION
Resolves #297

Seems that we already handle this in CLI. So this fixes TUI interface.

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [ ] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [x] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [x] Update documentation (README, haddock) if required.
- [x] Create a new test project using `summoner` and check that the changes work as expected.

*Hint:* Add the `[ci skip]` text to the docs-only related commit's name, so no need to wait for CI to pass.
