### PR TITLE
RFC: Replace Data.Monoid.Last with (Maybe Data.Semigroup.Last)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,15 @@
 packages: summoner-cli/ summoner-tui/
+
+repository head.hackage
+  url: http://head.hackage.haskell.org/
+  secure: True
+  root-keys: 07c59cb65787dedfaef5bd5f987ceb5f7e5ebf88b904bbd4c5cbdeb2ff71b740
+             2e8555dde16ebd8df076f1a8ef13b8f14c66bad8eafefd7d9e37d0ed711821fb
+             8f79fd2389ab2967354407ec852cbe73f2e8635793ac446d09461ffb99527f6e
+  key-threshold: 3 
+
+source-repository-package
+  type: git
+  location: https://github.com/sjakobi/generic-deriving
+  tag: becb9d44b08757f60cc78085d96df80715e7bde1
+

--- a/summoner-cli/src/Summoner/CLI.hs
+++ b/summoner-cli/src/Summoner/CLI.hs
@@ -27,7 +27,7 @@ import Development.GitRev (gitCommitDate, gitDirty, gitHash)
 import NeatInterpolation (text)
 import Options.Applicative (Parser, ParserInfo, argument, command, execParser, flag, fullDesc, help,
                             helper, info, infoFooter, infoHeader, infoOption, long, maybeReader,
-                            metavar, option, optional, progDesc, short, strArgument, strOption,
+                            metavar, option, progDesc, short, strArgument, strOption,
                             subparser, switch, value)
 import Options.Applicative.Help.Chunk (stringChunk)
 import Shellmet (($?), ($|))
@@ -47,6 +47,7 @@ import Summoner.Project (generateProject)
 import Summoner.Settings (CustomPrelude (..), Tool, parseTool)
 import Summoner.Template.Script (scriptFile)
 
+import qualified Data.Semigroup as S
 import qualified Data.Text as T
 import qualified Paths_summoner as Meta (version)
 
@@ -172,9 +173,9 @@ getFinalConfig NewOpts{..} = do
        gitName  <- (Just <$> "git" $| ["config", "user.name"])  $? pure Nothing
        gitEmail <- (Just <$> "git" $| ["config", "user.email"]) $? pure Nothing
        pure $ defaultConfig
-           { cOwner = Last gitOwner
-           , cFullName = Last gitName
-           , cEmail = Last gitEmail
+           { cOwner = S.Last <$> gitOwner
+           , cFullName = S.Last <$> gitName
+           , cEmail = S.Last <$> gitEmail
            }
 
 
@@ -338,7 +339,7 @@ newP = do
 
     pure $ New $ NewOpts
         { newOptsCliConfig = (maybeToMonoid $ with <> without)
-            { cPrelude = Last $ CustomPrelude <$> preludePack <*> preludeMod
+            { cPrelude = fmap S.Last $ CustomPrelude <$> preludePack <*> preludeMod
             , cCabal = cabal
             , cStack = stack
             , cNoUpload = Any $ noUpload || newOptsOffline

--- a/summoner-cli/src/Summoner/Source.hs
+++ b/summoner-cli/src/Summoner/Source.hs
@@ -6,7 +6,6 @@ module Summoner.Source
        , fetchSource
        ) where
 
-import Control.Arrow ((>>>))
 import Control.Exception (catch)
 import NeatInterpolation (text)
 import System.Process (readProcess)

--- a/summoner-cli/test/Test/TomlSpec.hs
+++ b/summoner-cli/test/Test/TomlSpec.hs
@@ -52,11 +52,11 @@ genSource = do
 
 genPartialConfig :: MonadGen m => m PartialConfig
 genPartialConfig = do
-    cOwner      <- fmap S.Last <$> Gen.maybe genText
-    cFullName   <- fmap S.Last <$> Gen.maybe genText
-    cEmail      <- fmap S.Last <$> Gen.maybe genText
-    cLicense    <- fmap S.Last <$> Gen.maybe genLicense
-    cGhcVer     <- fmap S.Last <$> Gen.maybe genGhcVerArr
+    cOwner      <- Gen.maybe $ S.Last <$> genText
+    cFullName   <- Gen.maybe $ S.Last <$> genText
+    cEmail      <- Gen.maybe $ S.Last <$> genText
+    cLicense    <- Gen.maybe $ S.Last <$> genLicense
+    cGhcVer     <- Gen.maybe $ S.Last <$> genGhcVerArr
     cCabal      <- genDecision
     cStack      <- genDecision
     cGitHub     <- genDecision
@@ -67,12 +67,12 @@ genPartialConfig = do
     cExe        <- genDecision
     cTest       <- genDecision
     cBench      <- genDecision
-    cPrelude    <- fmap S.Last <$> Gen.maybe genCustomPrelude
+    cPrelude    <- Gen.maybe $ S.Last <$> genCustomPrelude
     cExtensions <- genTextArr
     cWarnings   <- genTextArr
     cGhcOptions <- genTextArr
     cGitignore  <- genTextArr
-    cStylish    <- fmap S.Last <$> Gen.maybe genSource
-    cContributing <- fmap S.Last <$> Gen.maybe genSource
+    cStylish    <- Gen.maybe $ S.Last <$> genSource
+    cContributing <- Gen.maybe $ S.Last <$> genSource
     cNoUpload   <- Any <$> Gen.bool
     pure Config{..}

--- a/summoner-cli/test/Test/TomlSpec.hs
+++ b/summoner-cli/test/Test/TomlSpec.hs
@@ -2,6 +2,8 @@ module Test.TomlSpec
        ( tomlProp
        ) where
 
+import qualified Data.Semigroup as S
+
 import Hedgehog (MonadGen, Property, forAll, property, tripping)
 import Toml.Bi.Code (decode, encode)
 
@@ -50,11 +52,11 @@ genSource = do
 
 genPartialConfig :: MonadGen m => m PartialConfig
 genPartialConfig = do
-    cOwner      <- Last <$> Gen.maybe genText
-    cFullName   <- Last <$> Gen.maybe genText
-    cEmail      <- Last <$> Gen.maybe genText
-    cLicense    <- Last <$> Gen.maybe genLicense
-    cGhcVer     <- Last <$> Gen.maybe genGhcVerArr
+    cOwner      <- fmap S.Last <$> Gen.maybe genText
+    cFullName   <- fmap S.Last <$> Gen.maybe genText
+    cEmail      <- fmap S.Last <$> Gen.maybe genText
+    cLicense    <- fmap S.Last <$> Gen.maybe genLicense
+    cGhcVer     <- fmap S.Last <$> Gen.maybe genGhcVerArr
     cCabal      <- genDecision
     cStack      <- genDecision
     cGitHub     <- genDecision
@@ -65,12 +67,12 @@ genPartialConfig = do
     cExe        <- genDecision
     cTest       <- genDecision
     cBench      <- genDecision
-    cPrelude    <- Last <$> Gen.maybe genCustomPrelude
+    cPrelude    <- fmap S.Last <$> Gen.maybe genCustomPrelude
     cExtensions <- genTextArr
     cWarnings   <- genTextArr
     cGhcOptions <- genTextArr
     cGitignore  <- genTextArr
-    cStylish    <- Last <$> Gen.maybe genSource
-    cContributing <- Last <$> Gen.maybe genSource
+    cStylish    <- fmap S.Last <$> Gen.maybe genSource
+    cContributing <- fmap S.Last <$> Gen.maybe genSource
     cNoUpload   <- Any <$> Gen.bool
     pure Config{..}

--- a/summoner-tui/src/Summoner/Tui/Kit.hs
+++ b/summoner-tui/src/Summoner/Tui/Kit.hs
@@ -80,6 +80,8 @@ import Summoner.Tree (showTree)
 import qualified Data.List as List (delete)
 import qualified Data.Text as T
 
+import qualified Data.Semigroup as S
+
 
 -- | Global TUI state.
 data SummonKit = SummonKit
@@ -260,8 +262,8 @@ configToSummonKit cRepo cOffline cConfigFile Config{..} = SummonKit
     , summonKitExtensions   = cExtensions
     , summonKitGhcOptions   = cWarnings ++ cGhcOptions
     , summonKitGitignore    = cGitignore
-    , summonKitStylish      = getLast cStylish
-    , summonKitContributing = getLast cContributing
+    , summonKitStylish      = fmap S.getLast cStylish
+    , summonKitContributing = fmap S.getLast cContributing
     , summonKitOffline      = cOffline
     , summonKitShouldSummon = Nop
     , summonKitConfigFile   = cConfigFile
@@ -287,7 +289,7 @@ configToSummonKit cRepo cOffline cConfigFile Config{..} = SummonKit
         Idk -> False
 
     kitPreludeName, kitPreludeModule :: Text
-    (kitPreludeName, kitPreludeModule) = case getLast cPrelude of
+    (kitPreludeName, kitPreludeModule) = case S.getLast <$> cPrelude of
         Nothing                -> ("", "")
         Just CustomPrelude{..} -> (cpPackage, cpModule)
 


### PR DESCRIPTION
`Data.Monoid.First` and `Last` are [on track](https://gitlab.haskell.org/ghc/ghc/issues/15028) to be deprecated in GHC 8.8.

As I am [implementing](https://gitlab.haskell.org/ghc/ghc/merge_requests/842) the deprecation in GHC, I was wondering what this meant for a package that uses `Last` heavily.

For now I've tried replacing any type of  `Data.Monoid.Last a` with `Maybe (Data.Semigroup.Last a)`. An alternative (ha!) migration could use `Dual (Alt Maybe a)`.

The only real stumbling block was the `GMonoid` instance for `Maybe Data.Semigroup.Last a`. I could address this with [a little patch](https://github.com/dreixel/generic-deriving/pull/63).

Right now I'm mostly looking for feedback on the planned change. Do you like it? Do you have concerns that may have been overlooked so far?