### PR TITLE
[#341] Allow ansi-terminal 0.10

### DIFF
--- a/summoner-cli/summoner.cabal
+++ b/summoner-cli/summoner.cabal
@@ -96,7 +96,7 @@ library
 
   build-depends:       base-noprelude >= 4.10 && < 4.13
                      , aeson >= 1.2.4.0 && < 1.5
-                     , ansi-terminal >= 0.8 && < 0.10
+                     , ansi-terminal >= 0.8 && < 0.11
                      , bytestring ^>= 0.10.8.2
                      , directory ^>= 1.3.0.2
                      , filepath ^>= 1.4.1.2


### PR DESCRIPTION
Resolves #341

The changes implemented in `ansi-terminal-0.10` do not affect this package.

## Checklist:

* Update CHANGELOG _Not applicable_
    - [x] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [x] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [x] Update documentation (README, haddock) if required. _Not applicable_
- [x] Create a new test project using `summoner` and check that the changes work as expected. _Not applicable_