### PR TITLE
WIP: Add nix to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
   - ghc: 8.6.5
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml" DEPLOY=yes
 
+  - language: nix
+    install: echo 'Running nix...'
+    script: nix-shell --run 'cabal new-test all --enable-tests'
+
 #  Disabled because of Travis bugs
 #  # macOS build
 #  - env: GHCVER='8.6.3' STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml" DEPLOY=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ cache:
   - "$HOME/.stack"
   - "$TRAVIS_BUILD_DIR/.stack-work"
 
+before_script:
+  - nix-env -iA cachix -f https://cachix.org/api/v1/install
+  - cachix use kowainik
+
 matrix:
   include:
   # Cabal, linux
@@ -26,7 +30,7 @@ matrix:
 
   - language: nix
     install: echo 'Running nix...'
-    script: cachix use kowainik && nix-shell --run 'cabal new-test all --enable-tests'
+    script: nix-shell --run 'cabal new-test all --enable-tests'
 
 #  Disabled because of Travis bugs
 #  # macOS build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ cache:
   - "$HOME/.stack"
   - "$TRAVIS_BUILD_DIR/.stack-work"
 
-before_script:
-  - nix-env -iA cachix -f https://cachix.org/api/v1/install
-  - cachix use kowainik
-
 matrix:
   include:
   # Cabal, linux
@@ -29,8 +25,13 @@ matrix:
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml" DEPLOY=yes
 
   - language: nix
-    install: echo 'Running nix...'
-    script: nix-shell --run 'cabal new-test all --enable-tests'
+    install: 
+      - echo 'Running nix...'
+    before_script:
+      - nix-env -iA cachix -f https://cachix.org/api/v1/install
+      - cachix use kowainik
+    script: 
+      - nix-shell --run 'cabal new-test all --enable-tests'
 
 #  Disabled because of Travis bugs
 #  # macOS build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
   - language: nix
     install: echo 'Running nix...'
-    script: nix-shell --run 'cabal new-test all --enable-tests'
+    script: cachix use kowainik && nix-shell --run 'cabal new-test all --enable-tests'
 
 #  Disabled because of Travis bugs
 #  # macOS build


### PR DESCRIPTION
Resolves #336 

Travis is expected to timeout during the Nix build. The proposed fix is to use cachix. Perhaps a `kowainik` cache can be created by someone (who?) who will retain its private keys (and be authorized to push to it)?

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [x] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [x] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [x] Update documentation (README, haddock) if required.
- [ ] Create a new test project using `summoner` and check that the changes work as expected.

*Hint:* Add the `[ci skip]` text to the docs-only related commit's name, so no need to wait for CI to pass.
