### PR TITLE
[#314] Add base and lts versions to summon show ghc output

### DIFF
--- a/summoner-cli/CHANGELOG.md
+++ b/summoner-cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog is available [on GitHub][2].
 
 ## Unreleased
 
+* [#314](https://github.com/kowainik/summoner/issues/314):
+  Improve `summon show ghc` output
 * [#316](https://github.com/kowainik/summoner/issues/316):
   Add logos to README bagdes in the generated projects.
 * Generate project of version `0.0.0.0` instead of `0.0.0`.

--- a/summoner-cli/src/Summoner/CLI.hs
+++ b/summoner-cli/src/Summoner/CLI.hs
@@ -47,6 +47,7 @@ import Summoner.License (License (..), LicenseName (..), fetchLicense, parseLice
 import Summoner.Project (generateProject)
 import Summoner.Settings (CustomPrelude (..), Tool, parseTool)
 import Summoner.Template.Script (scriptFile)
+import Summoner.Text (alignTable)
 
 import qualified Data.Text as T
 import qualified Paths_summoner as Meta (version)
@@ -93,7 +94,7 @@ Available commands:
 runShow :: ShowOpts -> IO ()
 runShow = \case
     -- show list of all available GHC versions
-    GhcList -> showBulletList @GhcVer showGhcOutput (reverse universe)
+    GhcList -> showAlignedBulletList @GhcVer showGhcOutput (reverse universe)
     -- show a list of all available licenses
     LicenseList Nothing -> showBulletList @LicenseName showLicenseWithDesc universe
     -- show a specific license
@@ -108,6 +109,8 @@ runShow = \case
                 fetchedLicense <- fetchLicense licenseName
                 putTextLn $ unLicense fetchedLicense
   where
+    showAlignedBulletList :: (a -> [Text]) -> [a] -> IO()
+    showAlignedBulletList showT lst = mapM_ (infoMessage . T.append "➤ ") $ alignTable $ map showT lst
     showBulletList :: (a -> Text) -> [a] -> IO ()
     showBulletList showT = mapM_ (infoMessage . T.append "➤ " . showT)
 

--- a/summoner-cli/src/Summoner/CLI.hs
+++ b/summoner-cli/src/Summoner/CLI.hs
@@ -41,7 +41,7 @@ import Summoner.Config (Config, ConfigP (..), PartialConfig, defaultConfig, fina
                         loadFileConfig)
 import Summoner.Decision (Decision (..))
 import Summoner.Default (defaultConfigFile, defaultGHC)
-import Summoner.GhcVer (GhcVer, parseGhcVer, showGhcOutput)
+import Summoner.GhcVer (GhcVer, parseGhcVer, showGhcMeta)
 import Summoner.License (License (..), LicenseName (..), fetchLicense, parseLicenseName,
                          showLicenseWithDesc)
 import Summoner.Project (generateProject)
@@ -94,7 +94,7 @@ Available commands:
 runShow :: ShowOpts -> IO ()
 runShow = \case
     -- show list of all available GHC versions
-    GhcList -> showAlignedBulletList @GhcVer showGhcOutput (reverse universe)
+    GhcList -> showBulletList id $ alignTable $ map showGhcMeta $ reverse universe
     -- show a list of all available licenses
     LicenseList Nothing -> showBulletList @LicenseName showLicenseWithDesc universe
     -- show a specific license
@@ -109,8 +109,6 @@ runShow = \case
                 fetchedLicense <- fetchLicense licenseName
                 putTextLn $ unLicense fetchedLicense
   where
-    showAlignedBulletList :: (a -> [Text]) -> [a] -> IO()
-    showAlignedBulletList showT lst = mapM_ (infoMessage . T.append "➤ ") $ alignTable $ map showT lst
     showBulletList :: (a -> Text) -> [a] -> IO ()
     showBulletList showT = mapM_ (infoMessage . T.append "➤ " . showT)
 

--- a/summoner-cli/src/Summoner/CLI.hs
+++ b/summoner-cli/src/Summoner/CLI.hs
@@ -41,7 +41,7 @@ import Summoner.Config (Config, ConfigP (..), PartialConfig, defaultConfig, fina
                         loadFileConfig)
 import Summoner.Decision (Decision (..))
 import Summoner.Default (defaultConfigFile, defaultGHC)
-import Summoner.GhcVer (GhcVer, parseGhcVer, showGhcVer)
+import Summoner.GhcVer (GhcVer, parseGhcVer, showGhcOutput)
 import Summoner.License (License (..), LicenseName (..), fetchLicense, parseLicenseName,
                          showLicenseWithDesc)
 import Summoner.Project (generateProject)
@@ -93,7 +93,7 @@ Available commands:
 runShow :: ShowOpts -> IO ()
 runShow = \case
     -- show list of all available GHC versions
-    GhcList -> showBulletList @GhcVer showGhcVer (reverse universe)
+    GhcList -> showBulletList @GhcVer showGhcOutput (reverse universe)
     -- show a list of all available licenses
     LicenseList Nothing -> showBulletList @LicenseName showLicenseWithDesc universe
     -- show a specific license

--- a/summoner-cli/src/Summoner/GhcVer.hs
+++ b/summoner-cli/src/Summoner/GhcVer.hs
@@ -17,8 +17,6 @@ module Summoner.GhcVer
 
 import Data.List (maximum, minimum)
 
-import Summoner.Text (intercalateMap)
-
 import qualified Text.Show as Show
 
 
@@ -31,11 +29,12 @@ data GhcVer
     | Ghc865
     deriving (Eq, Ord, Show, Enum, Bounded)
 
-showGhcOutput :: GhcVer -> Text
-showGhcOutput ghcVer = intercalateMap " " ($ ghcVer) [ showGhcVer
-                                                     , ("base-" <>) . baseVer
-                                                     , ("lts-" <>) . latestLts
-                                                     ]
+showGhcOutput :: GhcVer -> [Text]
+showGhcOutput ghcVer = 
+    [showGhcVer ghcVer
+    ,"base-" <> baseVer ghcVer
+    ," lts-" <> latestLts ghcVer
+    ]
 
 -- | Converts 'GhcVer' into dot-separated string.
 showGhcVer :: GhcVer -> Text

--- a/summoner-cli/src/Summoner/GhcVer.hs
+++ b/summoner-cli/src/Summoner/GhcVer.hs
@@ -5,6 +5,7 @@ and some useful functions for manipulation with them.
 module Summoner.GhcVer
        ( GhcVer (..)
        , Pvp (..)
+       , showGhcOutput
        , showGhcVer
        , parseGhcVer
        , latestLts
@@ -15,6 +16,8 @@ module Summoner.GhcVer
        ) where
 
 import Data.List (maximum, minimum)
+
+import Summoner.Text (intercalateMap)
 
 import qualified Text.Show as Show
 
@@ -27,6 +30,12 @@ data GhcVer
     | Ghc844
     | Ghc865
     deriving (Eq, Ord, Show, Enum, Bounded)
+
+showGhcOutput :: GhcVer -> Text
+showGhcOutput ghcVer = intercalateMap " " ($ ghcVer) [ showGhcVer
+                                                     , ("base-" <>) . baseVer
+                                                     , ("lts-" <>) . latestLts
+                                                     ]
 
 -- | Converts 'GhcVer' into dot-separated string.
 showGhcVer :: GhcVer -> Text

--- a/summoner-cli/src/Summoner/GhcVer.hs
+++ b/summoner-cli/src/Summoner/GhcVer.hs
@@ -5,7 +5,7 @@ and some useful functions for manipulation with them.
 module Summoner.GhcVer
        ( GhcVer (..)
        , Pvp (..)
-       , showGhcOutput
+       , showGhcMeta
        , showGhcVer
        , parseGhcVer
        , latestLts
@@ -29,12 +29,13 @@ data GhcVer
     | Ghc865
     deriving (Eq, Ord, Show, Enum, Bounded)
 
-showGhcOutput :: GhcVer -> [Text]
-showGhcOutput ghcVer = 
-    [showGhcVer ghcVer
-    ,"base-" <> baseVer ghcVer
-    ," lts-" <> latestLts ghcVer
-    ]
+-- | This function shows GHC along with corresponding base and lts versions
+showGhcMeta :: GhcVer -> (Text, Text, Text)
+showGhcMeta ghcVer =
+    ( "ghc-"  <> showGhcVer ghcVer
+    , "base-" <> baseVer ghcVer
+    , "lts-"  <> latestLts ghcVer
+    )
 
 -- | Converts 'GhcVer' into dot-separated string.
 showGhcVer :: GhcVer -> Text

--- a/summoner-cli/src/Summoner/Text.hs
+++ b/summoner-cli/src/Summoner/Text.hs
@@ -45,4 +45,4 @@ padWord :: Int -> Text -> Text
 padWord maxWordLength word = word <> T.replicate (maxWordLength - T.length word) " "
 
 getMaxLengths :: [[Text]] -> [Int]
-getMaxLengths rows = map maximum $ map (map T.length) (transpose rows)
+getMaxLengths rows = map (maximum . map T.length) (transpose rows)

--- a/summoner-cli/src/Summoner/Text.hs
+++ b/summoner-cli/src/Summoner/Text.hs
@@ -6,7 +6,7 @@ module Summoner.Text
        , alignTable
        ) where
 
-import Data.Semigroup (Max (Max), getMax)
+import Data.Semigroup (Max (..))
 
 import qualified Data.Char as C
 import qualified Data.Text as T
@@ -34,15 +34,22 @@ tconcatMap f = T.concat . map f
 alignTable :: [(Text, Text, Text)] -> [Text]
 alignTable metas = map (formatTriple maxLengths) metas
     where 
-      maxLengths :: (Max Int, Max Int, Max Int)
-      maxLengths = getMaxLengths metas 
+      maxLengths :: (Int, Int, Int)
+      maxLengths = mapTriple getMax $ getMaxLengths metas 
 
-formatTriple :: (Max Int, Max Int, Max Int) -> (Text, Text, Text) -> Text
+formatTriple :: (Int, Int, Int) -> (Text, Text, Text) -> Text
 formatTriple (lenA, lenB, lenC) (a, b, c) = 
-    padWord lenA a <> " " <> padWord lenB b <> " " <> padWord lenC c
+    padRight lenA a <> " " <> padRight lenB b <> " " <> padRight lenC c
 
-padWord :: Max Int -> Text -> Text
-padWord maxWordLength word = word <> T.replicate (getMax maxWordLength - T.length word) " "
+{- |
+@padRight n t@ pads the text 't' with spaces on the right until it reaches length 'n'.
+@
+padRight 10 "hello"' ≡ "hello     "
+padRight  3 "hello"' ≡ "hello"
+@
+-}
+padRight :: Int -> Text -> Text
+padRight n t = t <> T.replicate (n - T.length t) " "
 
 getMaxLengths :: [(Text, Text, Text)] -> (Max Int, Max Int, Max Int)
 getMaxLengths = foldMap (mapTriple (Max . T.length))

--- a/summoner-cli/src/Summoner/Text.hs
+++ b/summoner-cli/src/Summoner/Text.hs
@@ -3,7 +3,10 @@ module Summoner.Text
        , intercalateMap
        , headToUpper
        , tconcatMap
+       , alignTable
        ) where
+
+import Data.List (maximum)
 
 import qualified Data.Char as C
 import qualified Data.Text as T
@@ -26,3 +29,20 @@ headToUpper t = case T.uncons t of
 -- | Convert every element of a list into text, and squash the results
 tconcatMap :: (a -> Text) -> [a] -> Text
 tconcatMap f = T.concat . map f
+
+-- | Aligns a list of texts by their columns
+alignTable :: [[Text]] -> [Text]
+alignTable ghcOutputs = map (T.intercalate " ") $
+    transpose $ zipWith padRow (transpose ghcOutputs) maxWordLengths 
+    where 
+      maxWordLengths :: [Int]
+      maxWordLengths = getMaxLengths ghcOutputs 
+
+padRow :: [Text] -> Int -> [Text] 
+padRow row maxWordLength = map (padWord maxWordLength) row
+
+padWord :: Int -> Text -> Text
+padWord maxWordLength word = word <> T.replicate (maxWordLength - T.length word) " "
+
+getMaxLengths :: [[Text]] -> [Int]
+getMaxLengths rows = map maximum $ map (map T.length) (transpose rows)

--- a/summoner-tui/CHANGELOG.md
+++ b/summoner-tui/CHANGELOG.md
@@ -3,6 +3,11 @@
 `summoner-tui` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## Unreleased
+
+* [#314](https://github.com/kowainik/summoner/issues/314):
+  Improve `summon show ghc` output
+
 ## 0.1.0 — Apr 9, 2019
 
 * Upgrade to `summoner-1.3.0`.

--- a/summoner-tui/src/Summoner/Tui.hs
+++ b/summoner-tui/src/Summoner/Tui.hs
@@ -27,15 +27,15 @@ import Brick.Widgets.List (listSelectedAttr, listSelectedFocusedAttr)
 import Lens.Micro ((.~), (^.))
 import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 
-import Summoner.Text (alignTable)
 import Summoner.Ansi (errorMessage, infoMessage)
 import Summoner.CLI (Command (..), NewOpts (..), ShowOpts (..), getFinalConfig, runScript, summon)
 import Summoner.Decision (Decision (..))
 import Summoner.Default (defaultConfigFile)
-import Summoner.GhcVer (showGhcOutput)
+import Summoner.GhcVer (showGhcMeta)
 import Summoner.License (License (..), LicenseName, fetchLicense, parseLicenseName,
                          showLicenseWithDesc)
 import Summoner.Project (initializeProject)
+import Summoner.Text (alignTable)
 import Summoner.Tui.Field (disabledAttr)
 import Summoner.Tui.Form (KitForm, SummonForm (..), getCurrentFocus, isActive, mkForm, recreateForm)
 import Summoner.Tui.Kit
@@ -259,7 +259,7 @@ runTuiShowGhcVersions :: IO ()
 runTuiShowGhcVersions = runSimpleApp drawGhcVersions
   where
     drawGhcVersions :: Widget ()
-    drawGhcVersions = listInBorder "Supported GHC versions" 60 0 $ alignTable (map showGhcOutput universe)
+    drawGhcVersions = listInBorder "Supported GHC versions" 60 0 $ alignTable (map showGhcMeta universe)
 
 runTuiShowAllLicenses :: IO ()
 runTuiShowAllLicenses = runSimpleApp drawLicenseNames

--- a/summoner-tui/src/Summoner/Tui.hs
+++ b/summoner-tui/src/Summoner/Tui.hs
@@ -27,6 +27,7 @@ import Brick.Widgets.List (listSelectedAttr, listSelectedFocusedAttr)
 import Lens.Micro ((.~), (^.))
 import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 
+import Summoner.Text (alignTable)
 import Summoner.Ansi (errorMessage, infoMessage)
 import Summoner.CLI (Command (..), NewOpts (..), ShowOpts (..), getFinalConfig, runScript, summon)
 import Summoner.Decision (Decision (..))
@@ -258,7 +259,7 @@ runTuiShowGhcVersions :: IO ()
 runTuiShowGhcVersions = runSimpleApp drawGhcVersions
   where
     drawGhcVersions :: Widget ()
-    drawGhcVersions = listInBorder "Supported GHC versions" 60 0 (map showGhcOutput universe)
+    drawGhcVersions = listInBorder "Supported GHC versions" 60 0 $ alignTable (map showGhcOutput universe)
 
 runTuiShowAllLicenses :: IO ()
 runTuiShowAllLicenses = runSimpleApp drawLicenseNames

--- a/summoner-tui/src/Summoner/Tui.hs
+++ b/summoner-tui/src/Summoner/Tui.hs
@@ -31,7 +31,7 @@ import Summoner.Ansi (errorMessage, infoMessage)
 import Summoner.CLI (Command (..), NewOpts (..), ShowOpts (..), getFinalConfig, runScript, summon)
 import Summoner.Decision (Decision (..))
 import Summoner.Default (defaultConfigFile)
-import Summoner.GhcVer (showGhcVer)
+import Summoner.GhcVer (showGhcOutput)
 import Summoner.License (License (..), LicenseName, fetchLicense, parseLicenseName,
                          showLicenseWithDesc)
 import Summoner.Project (initializeProject)
@@ -258,7 +258,7 @@ runTuiShowGhcVersions :: IO ()
 runTuiShowGhcVersions = runSimpleApp drawGhcVersions
   where
     drawGhcVersions :: Widget ()
-    drawGhcVersions = listInBorder "Supported GHC versions" 30 0 (map showGhcVer universe)
+    drawGhcVersions = listInBorder "Supported GHC versions" 60 0 (map showGhcOutput universe)
 
 runTuiShowAllLicenses :: IO ()
 runTuiShowAllLicenses = runSimpleApp drawLicenseNames


### PR DESCRIPTION
Resolves #314 

Been trying to align the words in the columns but getting stumped due to having to wrangle with showBulletList. Any tips? I seem to have bitten off a bit more than i can chew here haha

Currently the output looks like this: 
```
  ➤ 8.6.5 base-4.12.0.0 lts-13.27
  ➤ 8.4.4 base-4.11.1.0 lts-12.26
  ➤ 8.2.2 base-4.10.1.0 lts-11.22
  ➤ 8.0.2 base-4.9.1.0 lts-9.21 
  ➤ 7.10.3 base-4.8.0.2 lts-6.35 
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [x] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [x] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [ ] Update documentation (README, haddock) if required.
- [ ] Create a new test project using `summoner` and check that the changes work as expected.

*Hint:* Add the `[ci skip]` text to the docs-only related commit's name, so no need to wait for CI to pass.
