### PR TITLE
Autofill prelude module name when package name is typed

### DIFF
--- a/summoner-tui/CHANGELOG.md
+++ b/summoner-tui/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog is available [on GitHub][2].
 
 * [#314](https://github.com/kowainik/summoner/issues/314):
   Improve `summon show ghc` output
+* [#255](https://github.com/kowainik/summoner/issues/255)
+  Autofill custom prelude module name when package name is being typed.
 
 ## 0.1.0 — Apr 9, 2019
 

--- a/summoner-tui/src/Summoner/Tui.hs
+++ b/summoner-tui/src/Summoner/Tui.hs
@@ -181,6 +181,7 @@ appNew dirs = App
                 then loopWhileInactive ev newForm
                 else continue newForm
 
+    -- Autofill is only triggered on characters and backspace keys.
     keyTriggersAutofill :: V.Key -> Bool
     keyTriggersAutofill (V.KChar _) = True
     keyTriggersAutofill V.KBS       = True

--- a/summoner-tui/src/Summoner/Tui.hs
+++ b/summoner-tui/src/Summoner/Tui.hs
@@ -39,7 +39,7 @@ import Summoner.Text (alignTable)
 import Summoner.Tui.Field (disabledAttr)
 import Summoner.Tui.Form (KitForm, SummonForm (..), getCurrentFocus, isActive, mkForm, recreateForm)
 import Summoner.Tui.Kit
-import Summoner.Tui.Validation (ctrlD, formErrorMessages, summonFormValidation)
+import Summoner.Tui.Validation (ctrlD, formErrorMessages, handleAutofill, summonFormValidation)
 import Summoner.Tui.Widget (borderLabel, listInBorder)
 
 import qualified Brick (on)
@@ -123,6 +123,12 @@ appNew dirs = App
             VtyEvent (V.EvKey (V.KChar ' ') []) -> case getCurrentFocus s of
                 Nothing    -> withFormDef ev s
                 Just field -> handleCheckboxActivation ev s field
+
+            -- Run handler for autofill actions
+            VtyEvent (V.EvKey key [])
+                | keyTriggersAutofill key
+                -> withForm ev s (validateForm . handleAutofill)
+
             MouseDown n _ _ _ -> handleCheckboxActivation ev s n
 
             -- Handle skip of deactivated checkboxes
@@ -174,6 +180,11 @@ appNew dirs = App
             Just field -> if not $ isActive (formState newForm) field
                 then loopWhileInactive ev newForm
                 else continue newForm
+
+    keyTriggersAutofill :: V.Key -> Bool
+    keyTriggersAutofill (V.KChar _) = True
+    keyTriggersAutofill V.KBS       = True
+    keyTriggersAutofill _           = False
 
 -- | Draws the form for @new@ command.
 drawNew :: [FilePath] -> KitForm e -> [Widget SummonForm]

--- a/summoner-tui/src/Summoner/Tui/Validation.hs
+++ b/summoner-tui/src/Summoner/Tui/Validation.hs
@@ -6,11 +6,13 @@ module Summoner.Tui.Validation
        ( ctrlD
        , summonFormValidation
        , formErrorMessages
+       , handleAutofill
        ) where
 
 import Brick.Forms (formState, invalidFields, setFieldValid, setFormFocus)
 import Lens.Micro (Lens', (.~), (^.))
 
+import Summoner.Text (packageToModule)
 import Summoner.Tui.Form (KitForm, SummonForm (..), getCurrentFocus, mkForm)
 import Summoner.Tui.Kit
 
@@ -35,6 +37,17 @@ ctrlD =
         if getCurrentFocus f == Just formField
         then setFormFocus formField $ mkForm $ formState f & fieldLens .~ nil
         else f
+
+handleAutofill :: KitForm e -> KitForm e
+handleAutofill f =
+  case getCurrentFocus f of
+    Just CustomPreludeName ->
+      let prelude_name = formState f ^. projectMeta . preludeName
+          new_state = formState f & projectMeta . preludeModule .~ packageToModule prelude_name
+      in
+          setFormFocus CustomPreludeName $ mkForm new_state
+    _ -> f
+
 
 -- | Validates the main @new@ command form.
 summonFormValidation :: forall e . [FilePath] -> KitForm e -> KitForm e


### PR DESCRIPTION
Resolves #255

Demo: https://asciinema.org/a/ZBozTD81nqMUpBGnf09jhM1xr

## Checklist:

* Update CHANGELOG
    - [X] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [X] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [X] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [X] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [X] Update documentation (README, haddock) if required.
- [X] Create a new test project using `summoner` and check that the changes work as expected.