### PR TITLE
[#333] Introduce Map field for custom files to config

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,8 @@
 packages: summoner-cli/ summoner-tui/
 
 tests: true
+
+source-repository-package
+    type: git
+    location: https://github.com/kowainik/tomland
+    tag: f06fa1c72a4c4cf5dd6fbc988d920f62d1eb30af

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -9,3 +9,6 @@ extra-deps:
   - brick-0.50
   - relude-0.6.0.0
   - vty-5.26
+
+  - github: kowainik/tomland
+    commit: f06fa1c72a4c4cf5dd6fbc988d920f62d1eb30af

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,6 @@ packages:
 
 extra-deps:
   - optparse-applicative-0.15.0.0
+
+  - github: kowainik/tomland
+    commit: f06fa1c72a4c4cf5dd6fbc988d920f62d1eb30af

--- a/summoner-cli/summoner.cabal
+++ b/summoner-cli/summoner.cabal
@@ -115,7 +115,7 @@ library
                      , shellmet >= 0.0.1 && < 0.1
                      , text ^>= 1.2.3.0
                      , time >= 1.8 && < 1.10
-                     , tomland >= 1.0 && < 1.3
+                     , tomland ^>= 1.2.1.0
 
 executable summon
   import:              common-options

--- a/summoner-cli/test/Test/TomlSpec.hs
+++ b/summoner-cli/test/Test/TomlSpec.hs
@@ -5,7 +5,7 @@ module Test.TomlSpec
 import Hedgehog (MonadGen, Property, forAll, property, tripping)
 import Toml.Bi.Code (decode, encode)
 
-import Summoner.Config (ConfigP (..), PartialConfig, configT)
+import Summoner.Config (ConfigP (..), PartialConfig, configCodec)
 import Summoner.CustomPrelude (CustomPrelude (..))
 import Summoner.GhcVer (GhcVer)
 import Summoner.License (LicenseName)
@@ -20,7 +20,7 @@ import qualified Hedgehog.Range as Range
 tomlProp :: Property
 tomlProp = property $ do
     configToml <- forAll genPartialConfig
-    tripping configToml (encode configT) (decode configT)
+    tripping configToml (encode configCodec) (decode configCodec)
 
 ----------------------------------------------------------------------------
 -- Generators
@@ -36,6 +36,9 @@ genText :: MonadGen m => m Text
 genText = Gen.text
     (Range.constant 1 11)
     Gen.alpha
+
+genString :: MonadGen m => m String
+genString = Gen.list (Range.constant 0 100) Gen.alphaNum
 
 genTextArr :: MonadGen m => m [Text]
 genTextArr = Gen.list (Range.constant 0 10) genText
@@ -83,4 +86,5 @@ genPartialConfig = do
     cStylish    <- Last <$> Gen.maybe genSource
     cContributing <- Last <$> Gen.maybe genSource
     cNoUpload   <- Any <$> Gen.bool
+    cFiles <- Gen.map (Range.constant 0 10) (liftA2 (,) genString genSource)
     pure Config{..}


### PR DESCRIPTION
This is only the first part of #333. You can see how the config will look like in this PR:

* https://github.com/kowainik/org/pull/36

I've tested it locally on this config, and it works. It parses correctly :+1: When I print to terminal, I see the following:

```
Config {
...
, cFiles = fromList
    [ (".github/CODEOWNERS"
      , Url "https://raw.githubusercontent.com/kowainik/org/master/.github/CODEOWNERS"
      )
    , ( ".stylish-haskell.yaml"
      , Url "https://raw.githubusercontent.com/kowainik/org/master/.stylish-haskell.yaml"
      )
    ]
}
```