### PR TITLE
[#374] Remove deprecated `warnings` field of the config

### DIFF
--- a/summoner-cli/CHANGELOG.md
+++ b/summoner-cli/CHANGELOG.md
@@ -62,6 +62,10 @@ The changelog is available [on GitHub][2].
 * [#373](https://github.com/kowainik/summoner/issues/373):
   Bump up to `tomldnd-1.2.1.0`.
 * Bump up to `relude-0.6.0.0`.
+* [#374](https://github.com/kowainik/summoner/issues/374):
+  Remove `warnings` field in TOML file which was deprecated in the previous release.
+
+  _Migration guide:_ Rename `warnings` field to `ghc-options` instead.
 
 ## 1.3.0.1 — Apr 10, 2019
 

--- a/summoner-cli/src/Summoner/Config.hs
+++ b/summoner-cli/src/Summoner/Config.hs
@@ -62,7 +62,6 @@ data ConfigP (p :: Phase) = Config
     , cBench        :: !Decision
     , cPrelude      :: !(Last CustomPrelude)
     , cExtensions   :: ![Text]
-    , cWarnings     :: ![Text]  -- ^ DEPRECATED: TODO: remove in 1.4.
     , cGhcOptions   :: ![Text]  -- ^ GHC options to add to each stanza
     , cGitignore    :: ![Text]
     , cStylish      :: !(Last Source)  -- ^ DEPRECATED: source to .stylish-haskell.yaml
@@ -140,7 +139,6 @@ defaultConfig = Config
     , cBench    = Idk
     , cPrelude  = Last Nothing
     , cExtensions = []
-    , cWarnings = []
     , cGhcOptions = []
     , cGitignore = []
     , cStylish  = Last Nothing
@@ -152,30 +150,29 @@ defaultConfig = Config
 -- | Identifies how to read 'Config' data from the @.toml@ file.
 configCodec :: TomlCodec PartialConfig
 configCodec = Config
-    <$> Toml.last Toml.text "owner"       .= cOwner
-    <*> Toml.last Toml.text "fullName"    .= cFullName
-    <*> Toml.last Toml.text "email"       .= cEmail
-    <*> Toml.last license   "license"     .= cLicense
-    <*> Toml.last ghcVerArr "ghcVersions" .= cGhcVer
-    <*> decision            "cabal"       .= cCabal
-    <*> decision            "stack"       .= cStack
-    <*> decision            "github"      .= cGitHub
-    <*> decision            "travis"      .= cTravis
-    <*> decision            "appveyor"    .= cAppVey
-    <*> decision            "private"     .= cPrivate
-    <*> decision            "lib"         .= cLib
-    <*> decision            "exe"         .= cExe
-    <*> decision            "test"        .= cTest
-    <*> decision            "bench"       .= cBench
-    <*> Toml.last preludeT  "prelude"     .= cPrelude
-    <*> textArr             "extensions"  .= cExtensions
-    <*> textArr             "warnings"    .= cWarnings
-    <*> textArr             "ghc-options" .= cGhcOptions
-    <*> textArr             "gitignore"   .= cGitignore
-    <*> Toml.last sourceT  "stylish"      .= cStylish
-    <*> Toml.last sourceT  "contributing" .= cContributing
-    <*> Toml.any           "noUpload"     .= cNoUpload
-    <*> filesCodec         "files"        .= cFiles
+    <$> Toml.last Toml.text "owner"        .= cOwner
+    <*> Toml.last Toml.text "fullName"     .= cFullName
+    <*> Toml.last Toml.text "email"        .= cEmail
+    <*> Toml.last license   "license"      .= cLicense
+    <*> Toml.last ghcVerArr "ghcVersions"  .= cGhcVer
+    <*> decision            "cabal"        .= cCabal
+    <*> decision            "stack"        .= cStack
+    <*> decision            "github"       .= cGitHub
+    <*> decision            "travis"       .= cTravis
+    <*> decision            "appveyor"     .= cAppVey
+    <*> decision            "private"      .= cPrivate
+    <*> decision            "lib"          .= cLib
+    <*> decision            "exe"          .= cExe
+    <*> decision            "test"         .= cTest
+    <*> decision            "bench"        .= cBench
+    <*> Toml.last preludeT  "prelude"      .= cPrelude
+    <*> textArr             "extensions"   .= cExtensions
+    <*> textArr             "ghc-options"  .= cGhcOptions
+    <*> textArr             "gitignore"    .= cGitignore
+    <*> Toml.last sourceT   "stylish"      .= cStylish
+    <*> Toml.last sourceT   "contributing" .= cContributing
+    <*> Toml.any            "noUpload"     .= cNoUpload
+    <*> filesCodec          "files"        .= cFiles
   where
     _GhcVer :: TomlBiMap GhcVer Toml.AnyValue
     _GhcVer = Toml._TextBy showGhcVer (maybeToRight "Wrong GHC version" . parseGhcVer)
@@ -230,7 +227,6 @@ finalise Config{..} = Config
     <*> pure cBench
     <*> pure cPrelude
     <*> pure cExtensions
-    <*> pure cWarnings
     <*> pure cGhcOptions
     <*> pure cGitignore
     <*> pure cStylish

--- a/summoner-cli/src/Summoner/Project.hs
+++ b/summoner-cli/src/Summoner/Project.hs
@@ -42,9 +42,6 @@ generateProject
     -> Config      -- ^ Given configurations.
     -> IO ()
 generateProject isOffline projectName Config{..} = do
-    unless (null cWarnings) $
-        warningMessage "Please, rename 'warnings' field if you use one, it will be removed in the very next release. Use 'ghc-options' instead."
-
     settingsRepo <- checkUniqueName projectName
     -- decide cabal stack or both
     (settingsCabal, settingsStack) <- getCabalStack (cCabal, cStack)
@@ -97,7 +94,7 @@ generateProject isOffline projectName Config{..} = do
             Just _  -> "base-noprelude"
 
     let settingsExtensions = cExtensions
-    let settingsGhcOptions = cWarnings ++ cGhcOptions
+    let settingsGhcOptions = cGhcOptions
     let settingsGitignore = cGitignore
 
 

--- a/summoner-cli/test/Test/TomlSpec.hs
+++ b/summoner-cli/test/Test/TomlSpec.hs
@@ -81,7 +81,6 @@ genPartialConfig = do
     cBench      <- genDecision
     cPrelude    <- Last <$> Gen.maybe genCustomPrelude
     cExtensions <- genTextArr
-    cWarnings   <- genTextArr
     cGhcOptions <- genTextArr
     cGitignore  <- genTextArr
     cStylish    <- Last <$> Gen.maybe genSource

--- a/summoner-tui/src/Summoner/Tui/Kit.hs
+++ b/summoner-tui/src/Summoner/Tui/Kit.hs
@@ -262,7 +262,7 @@ configToSummonKit cRepo cOffline cConfigFile files Config{..} = SummonKit
         , gitHubAppVeyor = toBool cAppVey && kitStack
         }
     , summonKitExtensions   = cExtensions
-    , summonKitGhcOptions   = cWarnings ++ cGhcOptions
+    , summonKitGhcOptions   = cGhcOptions
     , summonKitGitignore    = cGitignore
     , summonKitStylish      = getLast cStylish
     , summonKitContributing = getLast cContributing


### PR DESCRIPTION
Resolves #374

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* Update CHANGELOG
    - [x] [summoner-cli/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-cli/CHANGELOG.md).
    - [ ] [summoner-tui/CHANGELOG](https://github.com/kowainik/summoner/blob/master/summoner-tui/CHANGELOG.md).
- [x] Keep code style used in the changed files (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] Use the [`stylish-haskell` file](https://github.com/kowainik/summoner/blob/master/.stylish-haskell.yaml).
- [x] Update documentation (README, haddock) if required.
- [x] Create a new test project using `summoner` and check that the changes work as expected.

*Hint:* Add the `[ci skip]` text to the docs-only related commit's name, so no need to wait for CI to pass.
