### PR TITLE
[#382] Improve error logging when fetching the license from GitHub

### DIFF
--- a/summoner-cli/summoner.cabal
+++ b/summoner-cli/summoner.cabal
@@ -120,7 +120,7 @@ library
                      , neat-interpolation ^>= 0.3.2.2
                      , optparse-applicative ^>= 0.15
                      , process ^>= 1.6.1.0
-                     , shellmet >= 0.0.1 && < 0.1
+                     , shellmet ^>= 0.0.3.0
                      , text ^>= 1.2.3.0
                      , time >= 1.8 && < 1.10
                      , tomland ^>= 1.2.1.0


### PR DESCRIPTION
Resolves #382

I've tested; it still works when it works. However, I can't prove the error case, since downloading and parsing works for me. But error messages should be better now.