### PR TITLE
[#394] Warning if hub is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ The changelog is available [on GitHub][2].
 * [#246](https://github.com/kowainik/summoner/issues/246):
    Put common fields into common stanza `common-options`.
 * Bump default `cabal` version to `2.4` in the generated project.
+* [#394](https://github.com/kowainik/summoner/issues/394):
+  Do not crush when `hub` is not installed. Instead, print descriptive warning
+  message.
 
 ## 1.4.0.0 – Dec 25, 2019 🎅
 


### PR DESCRIPTION
Resolves #394

This is what user will see if `hub` is not installed: 
![image](https://user-images.githubusercontent.com/8126674/74976157-22ef0d80-5420-11ea-9246-30f0437564f2.png)
