### PR TITLE
Use hspec-hedgehog for property tests

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,3 +7,4 @@ packages:
 extra-deps:
   - colourista-0.0.0.0
   - generic-data-0.8.0.0
+  - hspec-hedgehog-0.0.1.1

--- a/summoner-cli/summoner.cabal
+++ b/summoner-cli/summoner.cabal
@@ -182,6 +182,7 @@ test-suite summoner-test
                      , filepath
                      , hedgehog >= 0.5.3 && < 1.1
                      , hspec >= 2.4.8
+                     , hspec-hedgehog ^>= 0.0.1.1
                      , neat-interpolation
                      , text
                      , tomland

--- a/summoner-cli/test/Spec.hs
+++ b/summoner-cli/test/Spec.hs
@@ -1,34 +1,22 @@
 module Main (main) where
 
-import Hedgehog (Group (..), checkParallel)
 import Test.Hspec (hspec)
 
 import Test.CustomPrelude (customPreludeSpec)
-import Test.DecisionSpec (decisionMonoidMempty, decisionSemigroupAssoc)
+import Test.DecisionSpec (decisionPropertySpec)
 import Test.Golden (goldenSpec)
 import Test.QuestionSpec (yesNoPromptSpec)
 import Test.Script (scriptSpec)
 import Test.Show (showCommandSpec)
-import Test.TomlSpec (tomlConfigSpec, tomlProp)
+import Test.TomlSpec (tomlSpec)
 
 
 main :: IO ()
-main = do
-    hspec $ do
-        yesNoPromptSpec
-        scriptSpec
-        showCommandSpec
-        goldenSpec
-        customPreludeSpec
-        tomlConfigSpec
-    ifM (checkParallel hedgehogTests) exitSuccess exitFailure
-
-hedgehogTests :: Group
-hedgehogTests = Group "Roundtrip properties"
-    [ decisionSemigroupAssoc `named` "Decision Semigroup:Assoc"
-    , decisionMonoidMempty   `named` "Decision Monoid:Mempty"
-    , tomlProp               `named` "decode . encode == id"
-    ]
-  where
-    named :: a -> b -> (b, a)
-    named = flip (,)
+main = hspec $ do
+    yesNoPromptSpec
+    scriptSpec
+    showCommandSpec
+    goldenSpec
+    customPreludeSpec
+    tomlSpec
+    decisionPropertySpec

--- a/summoner-cli/test/Test/DecisionSpec.hs
+++ b/summoner-cli/test/Test/DecisionSpec.hs
@@ -2,32 +2,33 @@
 {- HLINT ignore "Monoid law, left identity" -}
 
 module Test.DecisionSpec
-       ( decisionSemigroupAssoc
-       , decisionMonoidMempty
+       ( decisionPropertySpec
 
          -- * Gen
        , genDecision
        ) where
 
 import Hedgehog (MonadGen, Property, forAll, property, (===))
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
 
 import Summoner.Decision (Decision)
 
 import qualified Hedgehog.Gen as Gen
 
 
-decisionSemigroupAssoc :: Property
-decisionSemigroupAssoc = property $ do
-    x <- forAll genDecision
-    y <- forAll genDecision
-    z <- forAll genDecision
-    (x <> y) <> z === x <> (y <> z)
+decisionPropertySpec :: Spec
+decisionPropertySpec = describe "Decision property tests" $ do
+    it "Decision Semigroup:Assoc" $ hedgehog $ do
+        x <- forAll genDecision
+        y <- forAll genDecision
+        z <- forAll genDecision
+        (x <> y) <> z === x <> (y <> z)
 
-decisionMonoidMempty :: Property
-decisionMonoidMempty = property $ do
-    x <- forAll genDecision
-    x <> mempty === x
-    mempty <> x === x
+    it "Decision Monoid:Mempty" $ hedgehog $ do
+        x <- forAll genDecision
+        x <> mempty === x
+        mempty <> x === x
 
 genDecision :: MonadGen m => m Decision
 genDecision = Gen.enumBounded

--- a/summoner-cli/test/Test/TomlSpec.hs
+++ b/summoner-cli/test/Test/TomlSpec.hs
@@ -1,12 +1,12 @@
 module Test.TomlSpec
-       ( tomlConfigSpec
-       , tomlProp
+       ( tomlSpec
        ) where
 
-import Hedgehog (MonadGen, Property, forAll, property, tripping)
+import Hedgehog (MonadGen, forAll, tripping)
 import Relude.Extra.Enum (universe)
 import Relude.Extra.Validation (Validation (..))
 import Test.Hspec (Spec, describe, it, shouldReturn, shouldSatisfy)
+import Test.Hspec.Hedgehog (hedgehog)
 import Toml.Bi.Code (decode, encode)
 
 import Summoner.Config (ConfigP (..), PartialConfig, configCodec, defaultConfig, finalise)
@@ -22,6 +22,11 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 
+tomlSpec :: Spec
+tomlSpec = describe "TOML Testing" $ do
+    tomlConfigSpec
+    tomlProp
+
 tomlConfigSpec :: Spec
 tomlConfigSpec = describe "TOML configuration spec" $ do
     it "finalises default configuration" $
@@ -35,10 +40,11 @@ tomlConfigSpec = describe "TOML configuration spec" $ do
     isSuccess :: Validation e a -> Bool
     isSuccess = \case { Success _ -> True; _ -> False }
 
-tomlProp :: Property
-tomlProp = property $ do
-    configToml <- forAll genPartialConfig
-    tripping configToml (encode configCodec) (decode configCodec)
+tomlProp :: Spec
+tomlProp = describe "TOML property tests" $
+    it "decode . encode == id" $ hedgehog $ do
+        configToml <- forAll genPartialConfig
+        tripping configToml (encode configCodec) (decode configCodec)
 
 ----------------------------------------------------------------------------
 -- Generators


### PR DESCRIPTION
I absolutely liked [hspec-hedgehog](https://hackage.haskell.org/package/hspec-hedgehog) library and decided o try to use it. Seems like a very nice addition to our testing standards. Let me know what you think first, @chshersh !