### PR TITLE
Cabal template: mark more warnings as ghc8 only

### DIFF
--- a/summoner-cli/src/Summoner/Template/Cabal.hs
+++ b/summoner-cli/src/Summoner/Template/Cabal.hs
@@ -114,12 +114,12 @@ cabalFile Settings{..} = File (toString settingsRepo ++ ".cabal") cabalFileConte
     defaultGhcOptions =
         [text|
         ghc-options:         -Wall
-                             -Wcompat
+        if impl(ghc >= 8.0)
+          ghc-options:       -Wcompat
                              -Widentities
                              -Wincomplete-uni-patterns
                              -Wincomplete-record-updates
-        if impl(ghc >= 8.0)
-          ghc-options:       -Wredundant-constraints
+                             -Wredundant-constraints
         if impl(ghc >= 8.2)
           ghc-options:       -fhide-source-paths
         if impl(ghc >= 8.4)


### PR DESCRIPTION
I believe `-Wcompat`, `-Widentities`, `-Wincomplete-uni-patterns`, and `-Wincomplete-record-updates` are all ghc8 only.

So this change reflects that in the Cabal template.