### PR TITLE
Use headroom to prettify headers

### DIFF
--- a/summoner-cli/src/Summoner.hs
+++ b/summoner-cli/src/Summoner.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Main module that reexports all library components of the @summoner@.
 -}

--- a/summoner-cli/src/Summoner/CLI.hs
+++ b/summoner-cli/src/Summoner/CLI.hs
@@ -4,9 +4,12 @@
 {-# LANGUAGE TupleSections   #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.CLI
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains functions and data types to parse CLI inputs.
 -}

--- a/summoner-cli/src/Summoner/Config.hs
+++ b/summoner-cli/src/Summoner/Config.hs
@@ -7,9 +7,12 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Config
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Summoner configurations.
 -}

--- a/summoner-cli/src/Summoner/CustomPrelude.hs
+++ b/summoner-cli/src/Summoner/CustomPrelude.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.CustomPrelude
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module implements data type for representing custom alternative preludes.
 -}

--- a/summoner-cli/src/Summoner/Decision.hs
+++ b/summoner-cli/src/Summoner/Decision.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Decision
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Decision data type.
 -}

--- a/summoner-cli/src/Summoner/Default.hs
+++ b/summoner-cli/src/Summoner/Default.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Default
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains some default values to use.
 -}

--- a/summoner-cli/src/Summoner/GhcVer.hs
+++ b/summoner-cli/src/Summoner/GhcVer.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.GhcVer
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Contains data type for GHC versions supported by Summoner
 and some useful functions for manipulation with them.

--- a/summoner-cli/src/Summoner/License.hs
+++ b/summoner-cli/src/Summoner/License.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2020 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.License
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Data types that represent license names and license content and functions
 to work with them.

--- a/summoner-cli/src/Summoner/Mode.hs
+++ b/summoner-cli/src/Summoner/Mode.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2020 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Mode
+Copyright               : (c) 2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module introduces different modes in which the command-line interface
 could be.

--- a/summoner-cli/src/Summoner/Project.hs
+++ b/summoner-cli/src/Summoner/Project.hs
@@ -1,14 +1,17 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-{- HLINT ignore "Reduce duplication" -}
-
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Project
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module introduces functions for the project creation.
 -}
+
+{- HLINT ignore "Reduce duplication" -}
 
 module Summoner.Project
        ( generateProject

--- a/summoner-cli/src/Summoner/Question.hs
+++ b/summoner-cli/src/Summoner/Question.hs
@@ -3,9 +3,12 @@
 {-# LANGUAGE ViewPatterns #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Question
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains function to proper questioning in terminal.
 -}

--- a/summoner-cli/src/Summoner/Settings.hs
+++ b/summoner-cli/src/Summoner/Settings.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Settings
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Complete settings required for the project creation.
 -}

--- a/summoner-cli/src/Summoner/Source.hs
+++ b/summoner-cli/src/Summoner/Source.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Source
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains the 'Source' data that describes how to fetch custom files.
 -}

--- a/summoner-cli/src/Summoner/Template.hs
+++ b/summoner-cli/src/Summoner/Template.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Template
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains functions for the Haskell project template creation.
 -}

--- a/summoner-cli/src/Summoner/Template/Cabal.hs
+++ b/summoner-cli/src/Summoner/Template/Cabal.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Template.Cabal
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 @.cabal@ file template.
 -}

--- a/summoner-cli/src/Summoner/Template/Doc.hs
+++ b/summoner-cli/src/Summoner/Template/Doc.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Template.Doc
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Templates for various documentation files:
 

--- a/summoner-cli/src/Summoner/Template/GitHub.hs
+++ b/summoner-cli/src/Summoner/Template/GitHub.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE QuasiQuotes  #-}
 {-# LANGUAGE ViewPatterns #-}
 
-{-|
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+{- |
+Module                  : Summoner.Template.GitHub
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains template for GitHub related docs:
 

--- a/summoner-cli/src/Summoner/Template/Haskell.hs
+++ b/summoner-cli/src/Summoner/Template/Haskell.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Template.Haskell
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Templates for generated Haskell source code files.
 -}

--- a/summoner-cli/src/Summoner/Template/Script.hs
+++ b/summoner-cli/src/Summoner/Template/Script.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Template.Script
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 File templates for @cabal@ and @stack@ scripts.
 -}

--- a/summoner-cli/src/Summoner/Template/Stack.hs
+++ b/summoner-cli/src/Summoner/Template/Stack.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Template.Stack
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Templates for @stack.yaml@ files.
 -}

--- a/summoner-cli/src/Summoner/Text.hs
+++ b/summoner-cli/src/Summoner/Text.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Text
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Various helpful functions to work with 'Text'
 -}

--- a/summoner-cli/src/Summoner/Tree.hs
+++ b/summoner-cli/src/Summoner/Tree.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE ViewPatterns #-}
 
 {- |
-Copyright: (c) 2017-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tree
+Copyright               : (c) 2017-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Data type for representing filesystem structure via tree.
 -}

--- a/summoner-tui/src/Summoner/Tui.hs
+++ b/summoner-tui/src/Summoner/Tui.hs
@@ -2,9 +2,12 @@
 {-# LANGUAGE ViewPatterns #-}
 
 {- |
-Copyright: (c) 2018-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tui
+Copyright               : (c) 2018-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 TUI for the Summoner tool. See demo in the README.md file.
 -}

--- a/summoner-tui/src/Summoner/Tui/Field.hs
+++ b/summoner-tui/src/Summoner/Tui/Field.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE Rank2Types #-}
 
 {- |
-Copyright: (c) 2018-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tui.Field
+Copyright               : (c) 2018-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This modules adds necessary functions for Forms and Form fields
 that are not covered in @brick@ library.

--- a/summoner-tui/src/Summoner/Tui/Form.hs
+++ b/summoner-tui/src/Summoner/Tui/Form.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2018-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tui.Form
+Copyright               : (c) 2018-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 Form layout and form fields data types.
 -}

--- a/summoner-tui/src/Summoner/Tui/GroupBorder.hs
+++ b/summoner-tui/src/Summoner/Tui/GroupBorder.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2018-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tui.GroupBorder
+Copyright               : (c) 2018-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 @Brick@ library helper functions to group checkbox elements inside the form.
 This is not going to be the part of the library itself, so we will have it in

--- a/summoner-tui/src/Summoner/Tui/Kit.hs
+++ b/summoner-tui/src/Summoner/Tui/Kit.hs
@@ -4,9 +4,12 @@
 {-# LANGUAGE TemplateHaskell        #-}
 
 {- |
-Copyright: (c) 2018-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tui.Kit
+Copyright               : (c) 2018-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains data types to work with application form. 'SummonKit' is
 the data type containing the values manipulated by the fields in the form.

--- a/summoner-tui/src/Summoner/Tui/Validation.hs
+++ b/summoner-tui/src/Summoner/Tui/Validation.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE Rank2Types #-}
 
 {- |
-Copyright: (c) 2018-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tui.Validation
+Copyright               : (c) 2018-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains function to validate Form fields.
 -}

--- a/summoner-tui/src/Summoner/Tui/Widget.hs
+++ b/summoner-tui/src/Summoner/Tui/Widget.hs
@@ -1,7 +1,10 @@
 {- |
-Copyright: (c) 2018-2019 Kowainik
-SPDX-License-Identifier: MPL-2.0
-Maintainer: Kowainik <xrom.xkov@gmail.com>
+Module                  : Summoner.Tui.Widget
+Copyright               : (c) 2018-2020 Kowainik
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Kowainik <xrom.xkov@gmail.com>
+Stability               : Stable
+Portability             : Portable
 
 This module contains useful helpers to work with 'Widget's
 -}


### PR DESCRIPTION
Using [headroom](https://github.com/vaclavsvejcar/headroom) to manage headers automatically. I've performed the following steps:

1. Run `headroom init -l mpl2 -s summoner-cli/src/`
2. Manually edit `headroom` files
3. Run `headroom run -v "author=Kowainik" -v "year=2020"`

It's a nice tool :slightly_smiling_face: But there are a few things that stop us from using `headroom` in all our projects. Maybe my configuration is wrong in some places, so I would appreciate any tips.

1. Currently `headroom` doesn't replace the top-level module documentation, it always adds a new entry (even when `replace` mode is enabled)
2. It doesn't substitute `LONG_DESC` and `MODULE_NAME` variables.
3. It doesn't preserve existing years (since it doesn't replace the header) and doesn't update years automatically (but there are open issues about that).

I'm opening the PR so we can discuss possible configuration adjustments and the possibility to use `headroom` in our projects :slightly_smiling_face: 

cc @vaclavsvejcar