### PR TITLE
Add configuration for Headroom

### DIFF
--- a/.headroom.yaml
+++ b/.headroom.yaml
@@ -1,0 +1,33 @@
+## This is the configuration file for Headroom.
+## See https://github.com/vaclavsvejcar/headroom for more details.
+
+run-mode: replace
+
+source-paths:
+  - summoner-cli/src/
+  - summoner-tui/src/
+
+excluded-paths: []
+
+template-paths:
+  - headroom-templates
+
+variables:
+  author: Kowainik
+  email: xrom.xkov@gmail.com
+  _haskell_module_copyright: "(c) {{ _current_year }} {{ author }}"
+
+license-headers:
+  haskell:
+    put-after: ["^{-#"]
+    margin-after: 1
+    margin-before: 1
+    block-comment:
+      starts-with: "{- |"
+      ends-with: "-}"
+
+post-process:
+  update-copyright:
+    enabled: true
+    config:
+      selected-authors-only: ["{{ author }}"]

--- a/headroom-templates/haskell.mustache
+++ b/headroom-templates/haskell.mustache
@@ -1,0 +1,10 @@
+{- |
+Module                  : {{{ _haskell_module_name }}}
+Copyright               : {{{ _haskell_module_copyright }}}
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : {{ author }} <{{ email }}>
+Stability               : Stable
+Portability             : Portable
+
+{{{ _haskell_module_longdesc }}}
+-}


### PR DESCRIPTION
Hello,

as we discussed in #457, I prepared [Headroom](https://github.com/vaclavsvejcar/headroom) configuration for _Summoner_ to make integration easier for you 🙂

This PR expects that you use the up-to-date version from `master` branch, as the changes you requested to make integration with _Summoner_ are not released yet (will be part of the `0.3.0.0` major release).

Also there are two files where some manual action will be required:
1. `summoner-cli/src/Summoner/Template/GitHub.hs` - Due to the fact that the _Haddock_ module header starts with `{-|` and not `{- |` (difference in space), _Headroom_ doesn't detect this as valid license header and instead replacing it, it puts new one at the top. Changing the `{-|` to `{- |` should make it.
1. `summoner-cli/src/Summoner/Project.hs` - With proposed configuration, _Headroom_ will place the license header above the `HLint comment` comment. If you want to change this and tell _Headroom_ to place license header after language pragmas and/or _HLint_ comment, you can modify the `put-after` configuration to following: `put-after: ["^{-#", "^{- HLINT"]`

Hope this helps you and matches your needs, feel free to ask any question and together we can eventually adjust either the configuration or add some _Headroom_ functionality. 🙂