### PR TITLE
Point Travis CI badge to travis-ci.com/<repo_name>

### DIFF
--- a/summoner-cli/examples/cabal-full/README.md
+++ b/summoner-cli/examples/cabal-full/README.md
@@ -1,7 +1,7 @@
 # cabal-full
 
 [![GitHub CI](https://github.com/kowainik/cabal-full/workflows/CI/badge.svg)](https://github.com/kowainik/cabal-full/actions)
-[![Build status](https://img.shields.io/travis/kowainik/cabal-full.svg?logo=travis)](https://travis-ci.org/kowainik/cabal-full)
+[![Build status](https://img.shields.io/travis/kowainik/cabal-full.svg?logo=travis)](https://travis-ci.com/kowainik/cabal-full)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/github/kowainik/cabal-full?branch=master&svg=true)](https://ci.appveyor.com/project/kowainik/cabal-full)
 [![Hackage](https://img.shields.io/hackage/v/cabal-full.svg?logo=haskell)](https://hackage.haskell.org/package/cabal-full)
 [![BSD-3-Clause license](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)

--- a/summoner-cli/examples/full-batteries/README.md
+++ b/summoner-cli/examples/full-batteries/README.md
@@ -1,7 +1,7 @@
 # full-batteries
 
 [![GitHub CI](https://github.com/kowainik/full-batteries/workflows/CI/badge.svg)](https://github.com/kowainik/full-batteries/actions)
-[![Build status](https://img.shields.io/travis/kowainik/full-batteries.svg?logo=travis)](https://travis-ci.org/kowainik/full-batteries)
+[![Build status](https://img.shields.io/travis/kowainik/full-batteries.svg?logo=travis)](https://travis-ci.com/kowainik/full-batteries)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/github/kowainik/full-batteries?branch=master&svg=true)](https://ci.appveyor.com/project/kowainik/full-batteries)
 [![Hackage](https://img.shields.io/hackage/v/full-batteries.svg?logo=haskell)](https://hackage.haskell.org/package/full-batteries)
 [![Stackage Lts](http://stackage.org/package/full-batteries/badge/lts)](http://stackage.org/lts/package/full-batteries)

--- a/summoner-cli/examples/stack-full/README.md
+++ b/summoner-cli/examples/stack-full/README.md
@@ -1,6 +1,6 @@
 # stack-full
 
-[![Build status](https://img.shields.io/travis/kowainik/stack-full.svg?logo=travis)](https://travis-ci.org/kowainik/stack-full)
+[![Build status](https://img.shields.io/travis/kowainik/stack-full.svg?logo=travis)](https://travis-ci.com/kowainik/stack-full)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/github/kowainik/stack-full?branch=master&svg=true)](https://ci.appveyor.com/project/kowainik/stack-full)
 [![Hackage](https://img.shields.io/hackage/v/stack-full.svg?logo=haskell)](https://hackage.haskell.org/package/stack-full)
 [![Stackage Lts](http://stackage.org/package/stack-full/badge/lts)](http://stackage.org/lts/package/stack-full)

--- a/summoner-cli/src/Summoner/Template/Doc.hs
+++ b/summoner-cli/src/Summoner/Template/Doc.hs
@@ -82,7 +82,7 @@ docFiles Settings{..} =
 
         travisShield, travisLink, travisBadge :: Text
         travisShield = shieldsIo <> "travis/" <> ownerRepo <> ".svg?logo=travis"
-        travisLink   = "https://travis-ci.org/" <> ownerRepo
+        travisLink   = "https://travis-ci.com/" <> ownerRepo
         travisBadge  = makeBadge "Build status" travisShield travisLink
 
         appVeyorCom, appVeyorShield, appVeyorLink, appVeyorBadge :: Text


### PR DESCRIPTION
New repos are no longer available on <https://travis-ci.org>,
but only on <https://travis-ci.com>.

See also: https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps

Closes: #449