### PR TITLE
[#499] Bump `optparse-applicative` to use 0.16

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,4 @@ extra-deps:
   - tomland-1.3.0.0
   - validation-selective-0.1.0.0
   - microaeson-0.1.0.0
+  - optparse-applicative-0.16.0.0

--- a/summoner-cli/summoner.cabal
+++ b/summoner-cli/summoner.cabal
@@ -148,7 +148,7 @@ library
                      , generic-data ^>= 0.8.0.0
                      , gitrev ^>= 1.3.1
                      , microaeson ^>= 0.1.0.0
-                     , optparse-applicative ^>= 0.15
+                     , optparse-applicative ^>= 0.16
                      , process ^>= 1.6.1.0
                      , shellmet ^>= 0.0.3.0
                      , text ^>= 1.2.3.0


### PR DESCRIPTION
I bumped the version, confirmed that the code builds and the tests pass. I did some smoke testing of the CLI (`--version`, `--help` with and without subcmd, `new`). I was able to confirm that the bump really changes something - it fixes pcapriotti/optparse-applicative#379 .

Fixes #499