### PR TITLE
Link to community-managed GitHub Action repository (#522)

### DIFF
--- a/summoner-cli/examples/cabal-full/.github/workflows/ci.yml
+++ b/summoner-cli/examples/cabal-full/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2.3.3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:

--- a/summoner-cli/examples/full-batteries/.github/workflows/ci.yml
+++ b/summoner-cli/examples/full-batteries/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v2.3.3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v2.3.3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/summoner-cli/examples/stack-full/.github/workflows/ci.yml
+++ b/summoner-cli/examples/stack-full/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2.3.3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: haskell/actions/setup@v1
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/summoner-cli/src/Summoner/Template/GitHub.hs
+++ b/summoner-cli/src/Summoner/Template/GitHub.hs
@@ -127,7 +127,7 @@ gitHubFiles Settings{..} = concat
         <> memptyIfFalse settingsStack ghActionsStack
 
     ghcActionsCheckoutVersion = "@v2.3.3"
-    ghcActionsSetupHaskellVersion = "@v1.1.3"
+    ghcActionsSetupHaskellVersion = "@v1"
     ghcActionsCacheVersion = "@v2.1.2"
 
     ghActionsCabal :: [Text]
@@ -149,7 +149,7 @@ gitHubFiles Settings{..} = concat
         , "    - uses: actions/checkout" <> ghcActionsCheckoutVersion
         , "      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'"
         , ""
-        , "    - uses: actions/setup-haskell" <> ghcActionsSetupHaskellVersion
+        , "    - uses: haskell/actions/setup" <> ghcActionsSetupHaskellVersion
         , "      id: setup-haskell-cabal"
         , "      name: Setup Haskell"
         , "      with:"
@@ -193,7 +193,7 @@ gitHubFiles Settings{..} = concat
         , "    - uses: actions/checkout" <> ghcActionsCheckoutVersion
         , "      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'"
         , ""
-        , "    - uses: actions/setup-haskell" <> ghcActionsSetupHaskellVersion
+        , "    - uses: haskell/actions/setup" <> ghcActionsSetupHaskellVersion
         , "      name: Setup Haskell Stack"
         , "      with:"
         , "        ghc-version: ${{ matrix.ghc }}"


### PR DESCRIPTION
The `actions/setup-haskell` repository is archived and hasn't worked
correctly for some time. This patch changes occurrences of
`setup-haskell` to point to the blessed repository, which is
`haskell/actions/setup@v1.