### PR TITLE
Deprecate hub and replace it with gh

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ project-name/
 To start using Summoner make sure that you have the following tools installed on your machine:
 
 * [`git`](https://git-scm.com) ⩾ 2.28 – to initialize the GitHub repo.
-* [`hub`](https://github.com/github/hub) – to upload the project to GitHub.
+* [`gh`](https://github.com/cli/cli) – to upload the project to GitHub.
 * [`curl`](https://curl.haxx.se) – to download licenses.
 
 We also have minimal version requirements for build tools:
@@ -741,28 +741,25 @@ These commands display the list of supported GHC versions, or Licenses. Also, wh
 
 [[Back to the Table of Contents] ↑](#structure)
 
-> I want to use HTTPS remote for the created GitHub project, but it creates SSH one. How should I fix this?
+> I want to use SSH/HTTPS remote for the created GitHub project, but it creates the repository with the wrong protocol. How should I fix this?
 
-We are using `hub` tool to create the projects at GitHub. It uses SSH so that you would get the remote links in the following format:
+We use the official Github CLI tool (`gh`) to create the projects on GitHub.  `gh` has its own configuration for
+choosing HTTPS/SSH protocols. There are two options for configuring this:
 
-```
-git@github.com:user/repo.git
-```
-
-We can not change or configure this behaviour, but there are several workarounds in case you _need_ to use HTTPS link for the remote.
-
-1. Change the remote of the repository after its creation:
-   ```
-   git remote set-url origin https://github.com/user/repo.git
-   ```
-2. Change `hub` configurations globally. Simply run the following command:
-   ```shell
-   git config --global hub.protocol https
-   ```
-3. Alternatively, change `hub` configurations for a single session:
-   ```
-   export HUB_PROTOCOL="https"
-   ```
+- You can configure it permanently for the `gh` tool:
+  ```shell
+  # Set HTTPS as the default configuration
+  gh config set git_protocol https
+  # Set SSH as the default configuration
+  gh config set git_protocol ssh
+  ```
+- You can adjusting the remote configuration after the repository is created locally with
+  ```shell
+  # Set HTTPS as the remote URL
+  git remote set-url origin https://github.com/<OWNER>/<REPO>.git
+  # Set SSH as the remote URL
+  git remote set-url origin git@github.com:<OWNER>/<REPO>.git
+  ```
 
 <hr>
 

--- a/summoner-cli/src/Summoner/Project.hs
+++ b/summoner-cli/src/Summoner/Project.hs
@@ -95,7 +95,7 @@ generateProjectInteractive connectMode projectName ConfigP{..} = do
         infoMessage "Use 'gh' and 'git' commands manually in order to upload the project to GitHub"
     settingsPrivate  <- decisionIf
         (settingsGitHub && not settingsNoUpload)
-        (YesNoPrompt "private repository" "Create as a private repository (Requires a GitHub private repo plan)?")
+        (YesNoPrompt "private repository" "Create as a private repository?")
         cPrivate
     settingsGhActions <- decisionIf settingsGitHub (mkDefaultYesNoPrompt "GitHub Actions CI integration") cGhActions
     settingsTravis    <- decisionIf settingsGitHub (mkDefaultYesNoPrompt "Travis CI integration") cTravis

--- a/summoner-cli/src/Summoner/Project.hs
+++ b/summoner-cli/src/Summoner/Project.hs
@@ -92,7 +92,7 @@ generateProjectInteractive connectMode projectName ConfigP{..} = do
     let settingsNoUpload = getAny cNoUpload
     when settingsNoUpload $ do
         infoMessage "'No upload' option is selected. The project won't be uploaded to GitHub."
-        infoMessage "Use 'hub' and 'git' commands manually in order to upload the project to GitHub"
+        infoMessage "Use 'gh' and 'git' commands manually in order to upload the project to GitHub"
     settingsPrivate  <- decisionIf
         (settingsGitHub && not settingsNoUpload)
         (YesNoPrompt "private repository" "Create as a private repository (Requires a GitHub private repo plan)?")
@@ -290,32 +290,32 @@ doGithubCommands Settings{..} = do
     "git" ["commit", "-m", "Create the project"]
     unless settingsNoUpload $ do
         let repo = settingsOwner <> "/" <> settingsRepo
-        hubInstalled <- findExecutable "hub"
-        case hubInstalled of
+        ghInstalled <- findExecutable "gh"
+        case ghInstalled of
             Just _ -> do
-                isHubSuccess <- runHub repo
-                if isHubSuccess
+                isGHSuccess <- runGH repo
+                if isGHSuccess
                 then do
                     "git" ["push", "-u", "origin", "main"]
                     "git" ["remote", "set-head", "origin", "-a"]
                     successMessage "Project created:"
                     infoMessage $ "    https://github.com/" <> repo
                 else do
-                    warningMessage "Error running 'hub'. Possible reason: incorrect password."
-                    hubHelp repo
+                    warningMessage "Error running 'gh'. Possible reason: incorrect password."
+                    ghHelp repo
             Nothing -> do
-                warningMessage "'hub' is not found at this machine. Cannot create the GitHub repository."
-                warningMessage "Please install 'hub' for the proper work of Summoner."
-                hubHelp repo
+                warningMessage "'gh' is not found at this machine. Cannot create the GitHub repository."
+                warningMessage "Please install 'gh' for the proper work of Summoner."
+                ghHelp repo
   where
     -- Create repo on GitHub and return 'True' in case of sucsess
-    runHub :: Text -> IO Bool
-    runHub repo =
-        True <$ "hub" (["create", "-d", settingsDescription, repo]
-             ++ ["-p" | settingsPrivate])  -- Create private repository if asked so
+    runGH :: Text -> IO Bool
+    runGH repo =
+        True <$ "gh" (["repo", "create", "-d", settingsDescription, repo]
+             ++ ["--private" | settingsPrivate])  -- Create private repository if asked so
              $? pure False
 
-    hubHelp :: Text -> IO ()
-    hubHelp repo = do
+    ghHelp :: Text -> IO ()
+    ghHelp repo = do
         infoMessage "To finish the process manually you can run the following command:"
-        putTextLn $ "    $ hub create -d '" <> settingsDescription <> "' " <> repo <> memptyIfFalse settingsPrivate " -p"
+        putTextLn $ "    $ gh repo create -d '" <> settingsDescription <> "' " <> repo <> memptyIfFalse settingsPrivate " --private"


### PR DESCRIPTION
Since `hub` is no longer active (no releases since 2020), is no longer an official Github tool, and an official Github CLI tool now exists in `gh`, It might be best to move usage of `hub` to `gh`.

I wrote this for myself to use with the `main` branch of `summoner` (so that I could use it for a modern GHC version), and I thought there might be interest in keeping it here, so I decided to clean it up and submit it upstream.

If this change is wanted, but we don't want to deprecate `hub`, let me know: I can build in `gh` support as a fallback and fix the docs.

One additional change: Github no longer requires a paid plan for private repos, so I also updated that doc.